### PR TITLE
Add numericality validator to NullConstraintChecker

### DIFF
--- a/lib/database_consistency/checkers/column_checkers/null_constraint_checker.rb
+++ b/lib/database_consistency/checkers/column_checkers/null_constraint_checker.rb
@@ -38,6 +38,7 @@ module DatabaseConsistency
       def valid?
         validator?(ActiveModel::Validations::PresenceValidator) ||
           validator?(ActiveModel::Validations::InclusionValidator) ||
+          numericality_validator_without_allow_nil? ||
           nil_exclusion_validator? ||
           belongs_to_association?
       end
@@ -54,6 +55,13 @@ module DatabaseConsistency
         model.validators.grep(ActiveModel::Validations::ExclusionValidator).any? do |validator|
           Helper.check_inclusion?(validator.attributes, column.name) &&
             validator.options[:in].include?(nil)
+        end
+      end
+
+      def numericality_validator_without_allow_nil?
+        model.validators.grep(ActiveModel::Validations::NumericalityValidator).any? do |validator|
+          Helper.check_inclusion?(validator.attributes, column.name) &&
+            !validator.options[:allow_nil]
         end
       end
 

--- a/spec/checkers/null_constraint_checker_spec.rb
+++ b/spec/checkers/null_constraint_checker_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe DatabaseConsistency::Checkers::NullConstraintChecker do
 
   test_each_database do
     before do
-      define_database_with_entity { |table| table.string :email, null: false }
+      define_database_with_entity do |table|
+        table.string :email, null: false
+        table.integer :count, null: false
+      end
     end
 
     context 'when validation is missing' do
@@ -33,6 +36,36 @@ RSpec.describe DatabaseConsistency::Checkers::NullConstraintChecker do
           checker_name: 'NullConstraintChecker',
           table_or_model_name: klass.name,
           column_or_attribute_name: 'email',
+          status: :ok,
+          message: nil
+        )
+      end
+    end
+
+    context 'when has numericality validation with allow_nil' do
+      let(:klass) { define_class { |klass| klass.validates_numericality_of :count, allow_nil: true } }
+      subject(:checker) { described_class.new(model, klass.columns.last) }
+
+      specify do
+        expect(checker.report).to have_attributes(
+          checker_name: 'NullConstraintChecker',
+          table_or_model_name: klass.name,
+          column_or_attribute_name: 'count',
+          status: :fail,
+          message: 'column is required in the database but do not have presence validator'
+        )
+      end
+    end
+
+    context 'when has numericality validation without allow_nil' do
+      let(:klass) { define_class { |klass| klass.validates_numericality_of :count } }
+      subject(:checker) { described_class.new(model, klass.columns.last) }
+
+      specify do
+        expect(checker.report).to have_attributes(
+          checker_name: 'NullConstraintChecker',
+          table_or_model_name: klass.name,
+          column_or_attribute_name: 'count',
           status: :ok,
           message: nil
         )


### PR DESCRIPTION
According to Rails doc, `numerically` validator behaves like `presence: true` when `allow_nil` option is false.

Closes #56