### PR TITLE
Document technique to keep settings DRY

### DIFF
--- a/rails-example/.database_consistency.yml
+++ b/rails-example/.database_consistency.yml
@@ -44,3 +44,24 @@ Country:
 #     enabled: false
 # Company:
 #   enabled: false
+
+
+# Concerns can be emulated using YAML's anchors and aliases
+
+# 1. Define an anchor before declaring concern-related settings
+DateConcern: &ignore_date_concern
+  date:
+    NullConstraintChecker:
+      enabled: false
+NameConcern: &ignore_name_concern
+  name:
+    ColumnPresenceChecker:
+      enabled: false
+
+# Models using concerns
+# 2. Now include the relevant settings using aliases
+Event:
+  <<: *ignore_date_concern
+  <<: *ignore_name_concern
+Poll:
+  <<: *ignore_date_concern


### PR DESCRIPTION
Disabling false positives in settings can be a bit verbose.
This change in the Rails example documents how to avoid duplicating settings, by using YAML's anchors and aliases.
It focuses on concerns, as this was my use case, but can be used in other situations.