### PR TITLE
Adds unique index checker

### DIFF
--- a/lib/database_consistency.rb
+++ b/lib/database_consistency.rb
@@ -33,11 +33,15 @@ require 'database_consistency/checkers/validator_checkers/missing_unique_index_c
 require 'database_consistency/checkers/validators_fraction_checkers/validators_fraction_checker'
 require 'database_consistency/checkers/validators_fraction_checkers/column_presence_checker'
 
+require 'database_consistency/checkers/index_checkers/index_checker'
+require 'database_consistency/checkers/index_checkers/unique_index_checker'
+
 require 'database_consistency/processors/base_processor'
 require 'database_consistency/processors/associations_processor'
 require 'database_consistency/processors/validators_processor'
 require 'database_consistency/processors/columns_processor'
 require 'database_consistency/processors/validators_fractions_processor'
+require 'database_consistency/processors/indexes_processor'
 
 # The root module
 module DatabaseConsistency

--- a/lib/database_consistency/checkers/index_checkers/index_checker.rb
+++ b/lib/database_consistency/checkers/index_checkers/index_checker.rb
@@ -18,12 +18,6 @@ module DatabaseConsistency
       def table_or_model_name
         @table_or_model_name ||= model.name.to_s
       end
-
-      private
-
-      def index_columns
-        index.columns.map(&:to_s)
-      end
     end
   end
 end

--- a/lib/database_consistency/checkers/index_checkers/index_checker.rb
+++ b/lib/database_consistency/checkers/index_checkers/index_checker.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DatabaseConsistency
+  module Checkers
+    # The base class for table checkers
+    class IndexChecker < BaseChecker
+      attr_reader :model, :index
+
+      def initialize(model, index)
+        @model = model
+        @index = index
+      end
+
+      def column_or_attribute_name
+        @column_or_attribute_name ||= index.name.to_s
+      end
+
+      def table_or_model_name
+        @table_or_model_name ||= model.name.to_s
+      end
+
+      private
+
+      def index_columns
+        index.columns.map(&:to_s)
+      end
+    end
+  end
+end

--- a/lib/database_consistency/checkers/index_checkers/unique_index_checker.rb
+++ b/lib/database_consistency/checkers/index_checkers/unique_index_checker.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module DatabaseConsistency
+  module Checkers
+    # This class checks missing presence validator
+    class UniqueIndexChecker < IndexChecker
+      # Message templates
+      VALIDATOR_MISSING = 'index is unique in the database but do not have uniqueness validator'
+
+      private
+
+      # We skip check when:
+      #  - index is not unique
+      def preconditions
+        index.unique
+      end
+
+      # Table of possible statuses
+      # | validation | status |
+      # | ---------- | ------ |
+      # | provided   | ok     |
+      # | missing    | fail   |
+      #
+      def check
+        if valid?
+          report_template(:ok)
+        else
+          report_template(:fail, VALIDATOR_MISSING)
+        end
+      end
+
+      def valid?
+        model.validators.grep(ActiveRecord::Validations::UniquenessValidator).any? do |validator|
+          # scope can be either nil, a symbol/string or an array of symbols/strings
+          scope = [validator.options&.dig(:scope)].flatten.compact
+
+          validator.attributes.any? do |attribute|
+            validator_attributes = ([attribute] + scope).compact.map(&:to_s)
+
+            (index_columns - validator_attributes).blank? && (validator_attributes - index_columns).blank?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/database_consistency/helper.rb
+++ b/lib/database_consistency/helper.rb
@@ -34,5 +34,39 @@ module DatabaseConsistency
 
       associations
     end
+
+    # @return [Array<String>]
+    def extract_index_columns(index_columns)
+      return index_columns unless index_columns.is_a?(String)
+
+      index_columns.split(',')
+                   .map(&:strip)
+                   .map { |str| str.gsub(/lower\(/i, 'lower(') }
+                   .map { |str| str.gsub(/\(([^)]+)\)::\w+/, '\1') }
+                   .map { |str| str.gsub(/'([^)]+)'::\w+/, '\1') }
+    end
+
+    def sorted_uniqueness_validator_columns(attribute, validator, model)
+      uniqueness_validator_columns(attribute, validator, model).sort
+    end
+
+    def uniqueness_validator_columns(attribute, validator, model)
+      ([wrapped_attribute_name(attribute, validator)] + scope_columns(validator, model)).map(&:to_s)
+    end
+
+    def scope_columns(validator, model)
+      Array.wrap(validator.options[:scope]).map do |scope_item|
+        model._reflect_on_association(scope_item)&.foreign_key || scope_item
+      end
+    end
+
+    # @return [String]
+    def wrapped_attribute_name(attribute, validator)
+      if validator.options[:case_sensitive].nil? || validator.options[:case_sensitive]
+        attribute
+      else
+        "lower(#{attribute})"
+      end
+    end
   end
 end

--- a/lib/database_consistency/processors/base_processor.rb
+++ b/lib/database_consistency/processors/base_processor.rb
@@ -8,7 +8,8 @@ module DatabaseConsistency
         ColumnsProcessor,
         ValidatorsProcessor,
         AssociationsProcessor,
-        ValidatorsFractionsProcessor
+        ValidatorsFractionsProcessor,
+        IndexesProcessor
       ].flat_map do |processor|
         processor.new(configuration).reports
       end

--- a/lib/database_consistency/processors/indexes_processor.rb
+++ b/lib/database_consistency/processors/indexes_processor.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DatabaseConsistency
+  module Processors
+    # The class to process indexes
+    class IndexesProcessor < BaseProcessor
+      CHECKERS = [
+        Checkers::UniqueIndexChecker
+      ].freeze
+
+      private
+
+      def check
+        Helper.parent_models.flat_map do |model|
+          next unless configuration.enabled?(model.name.to_s)
+
+          indexes = ActiveRecord::Base.connection.indexes(model.table_name)
+
+          indexes.flat_map do |index|
+            enabled_checkers.map do |checker_class|
+              checker = checker_class.new(model, index)
+              checker.report_if_enabled?(configuration)
+            end
+          end
+        end.compact
+      end
+    end
+  end
+end

--- a/spec/checkers/missing_unique_index_checker_spec.rb
+++ b/spec/checkers/missing_unique_index_checker_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe DatabaseConsistency::Checkers::MissingUniqueIndexChecker do
           expect(checker.report).to have_attributes(
             checker_name: 'MissingUniqueIndexChecker',
             table_or_model_name: klass.name,
-            column_or_attribute_name: 'email+country',
+            column_or_attribute_name: 'country+email',
             status: :ok,
             message: nil
           )
@@ -92,7 +92,7 @@ RSpec.describe DatabaseConsistency::Checkers::MissingUniqueIndexChecker do
           expect(checker.report).to have_attributes(
             checker_name: 'MissingUniqueIndexChecker',
             table_or_model_name: klass.name,
-            column_or_attribute_name: 'email+country_id',
+            column_or_attribute_name: 'country_id+email',
             status: :ok,
             message: nil
           )
@@ -112,7 +112,7 @@ RSpec.describe DatabaseConsistency::Checkers::MissingUniqueIndexChecker do
           expect(checker.report).to have_attributes(
             checker_name: 'MissingUniqueIndexChecker',
             table_or_model_name: klass.name,
-            column_or_attribute_name: 'email+country',
+            column_or_attribute_name: 'country+email',
             status: :fail,
             message: 'model should have proper unique index in the database'
           )

--- a/spec/checkers/unique_index_checker_spec.rb
+++ b/spec/checkers/unique_index_checker_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+RSpec.describe DatabaseConsistency::Checkers::UniqueIndexChecker do
+  subject(:checker) { described_class.new(model, index) }
+
+  let(:model) { klass }
+  let(:index) { ActiveRecord::Base.connection.indexes(klass.table_name).first }
+
+  let(:checker_name) { described_class.to_s.split('::').last }
+  let(:index_name) { 'index_name' }
+
+  test_each_database do
+    context 'mono attribute index' do
+      before do
+        define_database_with_entity do |table|
+          table.string :first_name
+          table.string :email, index: { unique: true, name: index_name }
+        end
+      end
+
+      context 'when validation is present' do
+        let(:klass) { define_class { |klass| klass.validates :email, :first_name, uniqueness: true } }
+
+        specify do
+          expect(checker.report).to have_attributes(
+            checker_name: checker_name,
+            table_or_model_name: klass.name,
+            column_or_attribute_name: index_name,
+            status: :ok,
+            message: nil
+          )
+        end
+      end
+
+      context 'when validation is missing' do
+        let(:klass) { define_class }
+
+        specify do
+          expect(checker.report).to have_attributes(
+            checker_name: checker_name,
+            table_or_model_name: klass.name,
+            column_or_attribute_name: index_name,
+            status: :fail,
+            message: 'index is unique in the database but do not have uniqueness validator'
+          )
+        end
+      end
+    end
+
+    context 'two attributes index' do
+      before do
+        define_database_with_entity do |table|
+          table.string :first_name
+          table.string :email
+
+          table.index %i[first_name email], unique: true, name: index_name
+        end
+      end
+
+      context 'when validation is present one way' do
+        let(:klass) { define_class { |klass| klass.validates :email, uniqueness: { scope: :first_name } } }
+
+        specify do
+          expect(checker.report).to have_attributes(
+            checker_name: checker_name,
+            table_or_model_name: klass.name,
+            column_or_attribute_name: index_name,
+            status: :ok,
+            message: nil
+          )
+        end
+      end
+
+      context 'when validation is present the other way' do
+        let(:klass) { define_class { |klass| klass.validates :first_name, uniqueness: { scope: :email } } }
+
+        specify do
+          expect(checker.report).to have_attributes(
+            checker_name: checker_name,
+            table_or_model_name: klass.name,
+            column_or_attribute_name: index_name,
+            status: :ok,
+            message: nil
+          )
+        end
+      end
+
+      context 'when validation is missing' do
+        let(:klass) { define_class { |klass| klass.validates :first_name, uniqueness: true } }
+
+        specify do
+          expect(checker.report).to have_attributes(
+            checker_name: checker_name,
+            table_or_model_name: klass.name,
+            column_or_attribute_name: index_name,
+            status: :fail,
+            message: 'index is unique in the database but do not have uniqueness validator'
+          )
+        end
+      end
+    end
+
+    context 'three attributes index' do
+      before do
+        define_database_with_entity do |table|
+          table.string :first_name
+          table.string :last_name
+          table.string :email
+
+          table.index %i[first_name last_name email], unique: true, name: index_name
+        end
+      end
+
+      context 'when validation is present one way' do
+        let(:klass) { define_class { |klass| klass.validates :email, uniqueness: { scope: %i[first_name last_name] } } }
+
+        specify do
+          expect(checker.report).to have_attributes(
+            checker_name: checker_name,
+            table_or_model_name: klass.name,
+            column_or_attribute_name: index_name,
+            status: :ok,
+            message: nil
+          )
+        end
+      end
+
+      context 'when validation is present another way' do
+        let(:klass) { define_class { |klass| klass.validates :first_name, uniqueness: { scope: %i[email last_name] } } }
+
+        specify do
+          expect(checker.report).to have_attributes(
+            checker_name: checker_name,
+            table_or_model_name: klass.name,
+            column_or_attribute_name: index_name,
+            status: :ok,
+            message: nil
+          )
+        end
+      end
+
+      context 'when validation is missing' do
+        let(:klass) { define_class { |klass| klass.validates :first_name, uniqueness: { scope: :last_name } } }
+
+        specify do
+          expect(checker.report).to have_attributes(
+            checker_name: checker_name,
+            table_or_model_name: klass.name,
+            column_or_attribute_name: index_name,
+            status: :fail,
+            message: 'index is unique in the database but do not have uniqueness validator'
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #77

Summary:
- Adds index processor
- Adds index checker base class
- Adds unique index checker (database unique index exist but rails validation is missing)

- I've tried to match the code style and rubocop config as best I could. There is two remaining rubocop offenses on my code
```
lib/database_consistency/checkers/index_checkers/unique_index_checker.rb:32:7: C: Metrics/AbcSize: Assignment Branch 
lib/database_consistency/processors/indexes_processor.rb:13:7: C: Metrics/AbcSize: Assignment Branch Condition size for check is too high. [<5, 16, 4> 17.23/17]
```
do you want me to fix them?

- I haven't seen any specs for processors
- I've tested it on our code-base and it seems to work fine