### PR TITLE
Ignore ActiveStorage variants false positives

### DIFF
--- a/lib/database_consistency/templates/rails_defaults.yml
+++ b/lib/database_consistency/templates/rails_defaults.yml
@@ -5,3 +5,5 @@ ActiveStorage::Attachment:
   enabled: false
 ActiveStorage::Blob:
   enabled: false
+ActiveStorage::VariantRecord:
+  enabled: false


### PR DESCRIPTION
Since Rails 6.1, ActiveStorage stores variants metadata in a dedicated table (see [Pull Request 37901](https://github.com/rails/rails/pull/37901) for full explanation).
This addition ensures that the `install` command also adds the required configuration to prevent false positives caused by the `active_storage_variant_records` table.

Here are the failure messages displayed if the table is not ignored:
```
fail ActiveStorage::VariantRecord variation_digest column is required in the database but do not have presence validator
fail ActiveStorage::VariantRecord index_active_storage_variant_records_uniqueness index is unique in the database but do not have uniqueness validator
```