### PR TITLE
Implement MissingNotNullConstraintChecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Improvements:
+- Implement `MissingNotNullConstraintChecker`. Thanks [Phil Pirozhkov](https://github.com/pirj) for the contribution!
+
 ### [1.1.1] - 2021/04/25
 
 Bugs:

--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ the first unique constraint is redundant as it is covered by the second one.
 We fail if the following conditions are satisfied:
 - there is an unique index that consists only from columns for the current one.
 
+### MissingNotNullConstraintChecker
+
+This checker identifies tables with missing not-null constraint on a foreign key that is required in the model.
+
 ## Example
 
 ```

--- a/lib/database_consistency.rb
+++ b/lib/database_consistency.rb
@@ -22,6 +22,7 @@ require 'database_consistency/checkers/association_checkers/missing_index_checke
 require 'database_consistency/checkers/association_checkers/foreign_key_type_checker'
 
 require 'database_consistency/checkers/column_checkers/column_checker'
+require 'database_consistency/checkers/column_checkers/missing_not_null_constraint_checker'
 require 'database_consistency/checkers/column_checkers/null_constraint_checker'
 require 'database_consistency/checkers/column_checkers/length_constraint_checker'
 require 'database_consistency/checkers/column_checkers/primary_key_type_checker'

--- a/lib/database_consistency/checkers/column_checkers/missing_not_null_constraint_checker.rb
+++ b/lib/database_consistency/checkers/column_checkers/missing_not_null_constraint_checker.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module DatabaseConsistency
+  module Checkers
+    # This class checks if a foreign key column for a required +belongs_to+ has no not null constraint
+    class MissingNotNullConstraintChecker < ColumnChecker
+      MISSING_NOT_NULL_CONSTRAINT = 'FK allows for null in the database, but is required in the model'
+
+      private
+
+      def preconditions
+        recent_rails? &&
+          column.null &&
+          foreign_key &&
+          presence_validation_present?
+      end
+
+      def check
+        report_template(:fail, MISSING_NOT_NULL_CONSTRAINT)
+      end
+
+      def foreign_key
+        model.connection
+             .foreign_keys(model.table_name)
+             .find { |fk| fk.options[:column] == column.name }
+      end
+
+      def reflection
+        model
+          .reflections
+          .values
+          .find { |r| r.join_foreign_key == column.name }
+      end
+
+      def presence_validation_present?
+        model
+          .validators_on(reflection.name)
+          .grep(ActiveRecord::Validations::PresenceValidator)
+          .any?
+      end
+
+      def recent_rails?
+        ActiveRecord::VERSION::MAJOR >= 5
+      end
+    end
+  end
+end

--- a/lib/database_consistency/processors/columns_processor.rb
+++ b/lib/database_consistency/processors/columns_processor.rb
@@ -7,7 +7,8 @@ module DatabaseConsistency
       CHECKERS = [
         Checkers::NullConstraintChecker,
         Checkers::LengthConstraintChecker,
-        Checkers::PrimaryKeyTypeChecker
+        Checkers::PrimaryKeyTypeChecker,
+        Checkers::MissingNotNullConstraintChecker
       ].freeze
 
       private

--- a/spec/checkers/missing_not_null_constraint_checker_spec.rb
+++ b/spec/checkers/missing_not_null_constraint_checker_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+RSpec.describe DatabaseConsistency::Checkers::MissingNotNullConstraintChecker do
+  subject(:checker) { described_class.new(model, column) }
+
+  let(:model) { book_class }
+  let(:column) { model.columns.first }
+
+  before do
+    skip('older versions are not supported') if ActiveRecord::VERSION::MAJOR < 5
+  end
+
+  test_each_database do
+    context 'when NOT NULL is missing' do
+      before do
+        define_database do
+          create_table(:authors)
+          create_table(:books, id: false) do |books|
+            books.bigint :author_id, null: true
+            books.foreign_key :authors
+          end
+        end
+      end
+
+      context 'when `belongs_to` is `optional: false`' do
+        let(:book_class) do
+          define_class('Book', :books) do |book|
+            book.belongs_to :author, optional: false
+          end
+        end
+
+        it 'detects an inconsistency' do
+          expect(checker.report(false)).to have_attributes(
+            checker_name: 'MissingNotNullConstraintChecker',
+            table_or_model_name: book_class.name,
+            column_or_attribute_name: 'author_id',
+            status: :fail,
+            message: 'FK allows for null in the database, but is required in the model'
+          )
+        end
+      end
+
+      context 'when `belongs_to` is `optional: true`' do
+        let(:book_class) do
+          define_class('Book', :books) do |book|
+            book.belongs_to :author, optional: true
+          end
+        end
+
+        it 'passes' do
+          expect(checker.report(false)).to be_nil
+        end
+      end
+    end
+
+    context 'when NOT NULL is present' do
+      before do
+        define_database do
+          create_table(:authors)
+          create_table(:books, id: false) do |books|
+            books.bigint :author_id, null: false
+            books.foreign_key :authors
+          end
+        end
+      end
+
+      let(:book_class) do
+        define_class('Book', :books) do |book|
+          book.belongs_to :author, optional: false
+        end
+      end
+
+      it 'passes' do
+        expect(checker.report(false)).to be_nil
+      end
+    end
+
+    context 'when FK column name is different from association name' do
+      before do
+        define_database do
+          create_table(:users)
+          create_table(:books, id: false) do |books|
+            books.bigint :author_id, null: true
+            books.foreign_key :users, column: :author_id
+          end
+        end
+
+        define_class('User', :users)
+      end
+
+      let(:book_class) do
+        define_class('Book', :books) do |book|
+          book.belongs_to :author, class_name: 'User', optional: false
+        end
+      end
+
+      it 'detects an inconsistency' do
+        expect(checker.report(false)).to have_attributes(
+          checker_name: 'MissingNotNullConstraintChecker',
+          table_or_model_name: book_class.name,
+          column_or_attribute_name: 'author_id',
+          status: :fail,
+          message: 'FK allows for null in the database, but is required in the model'
+        )
+      end
+    end
+
+    context 'when FK is not defined and NOT NULL is missing' do
+      before do
+        define_database do
+          create_table(:authors)
+          create_table(:books, id: false) do |books|
+            books.bigint :author_id, null: true
+          end
+        end
+      end
+
+      let(:book_class) do
+        define_class('Book', :books) do |book|
+          book.belongs_to :author, optional: false
+        end
+      end
+
+      it 'passes (other checker takes care of this case)' do
+        expect(checker.report(false)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #90

Checks nullable columns that are used in FKs for associations for `belongs_to` with explicit (or implicit, which is the default since Rails 5.0) `optional: false`.

See:
 - https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/railties/lib/rails/application/configuration.rb#L81
 - https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to
 - https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html#method-i-foreign_key

On my current project, the success of this checker is tremendous, it managed to find 50 such columns (out of total ~300 found issues). At a glance, all legit.

https://guides.rubyonrails.org/v5.2/configuring.html:
> config.active_record.belongs_to_required_by_default is a boolean value and controls whether a record fails validation if belongs_to association is not present.

NOTE: `optional: false` was introduced in Rails 5.0 as an alternative an the default to `required: true`.

NOTE: `foreign_keys` is not implemented for sqlite3 on Rails 4.2. I've mimicked `spec/checkers/belongs_to_presence_checker_spec.rb` that skips specs.
⚠️ the checker itself will run and will error out, just like (supposedly) `BelongsToPresenceChecker`.

PS I'm giving up on Rails 4.2 support https://app.circleci.com/pipelines/github/djezzzl/database_consistency/166/workflows/b97855f0-c821-4e0f-963c-92a60ad6779a/jobs/403/tests#failed-test-0 due to:
 - lack of `foreign_keys` support for sqlite3
 - lack of `join_foreign_key`
 - weird mysql error when adding a FK