### PR TITLE
Add Rails 6.1 & 7.0 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,7 @@
 version: 2.1
-jobs:
-  ver4-2:
-    docker:
-      - image: circleci/ruby:2.5.5
-        environment:
-          BUNDLE_PATH: vendor/bundle
-          DB_HOST: 127.0.0.1
-          DB_USER: root
-          DB_PASSWORD: database_consistency_password
-          AR_VERSION: "~> 4.2"
-          SQLITE_VERSION: "~> 1.3.9"
-          MYSQL_VERSION: "~> 0.4.0"
 
-      - image: circleci/postgres:9.6
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: database_consistency_test
-          POSTGRES_PASSWORD: database_consistency_password
-
-      - image: circleci/mysql:5.6
-        environment:
-          MYSQL_ROOT_HOST: '%'
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: database_consistency_password
-          MYSQL_DATABASE: database_consistency_test
-
+commands:
+  test:
     steps:
       - checkout
 
@@ -52,15 +29,45 @@ jobs:
                               --out test_results/rspec.xml \
                               --format progress \
                               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+
       - store_test_results:
           path: test_results
 
-  ver5-2:
+jobs:
+  ver4-2:
     docker:
-      - image: circleci/ruby:2.6.3
+      - image: circleci/ruby:2.5.9
         environment:
           BUNDLE_PATH: vendor/bundle
-          AR_VERSION: "~> 5.2"
+          DB_HOST: 127.0.0.1
+          DB_USER: root
+          DB_PASSWORD: database_consistency_password
+          AR_VERSION: '~> 4.2'
+          SQLITE_VERSION: '~> 1.3.9'
+          MYSQL_VERSION: '~> 0.4.0'
+
+      - image: circleci/postgres:9.6
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: database_consistency_test
+          POSTGRES_PASSWORD: database_consistency_password
+
+      - image: circleci/mysql:5.6
+        environment:
+          MYSQL_ROOT_HOST: '%'
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: database_consistency_password
+          MYSQL_DATABASE: database_consistency_test
+
+    steps:
+      - test
+
+  ver5-2:
+    docker:
+      - image: circleci/ruby:2.6.8
+        environment:
+          BUNDLE_PATH: vendor/bundle
+          AR_VERSION: '~> 5.2'
           DB_HOST: 127.0.0.1
           DB_USER: root
           DB_PASSWORD: database_consistency_password
@@ -79,39 +86,14 @@ jobs:
           MYSQL_DATABASE: database_consistency_test
 
     steps:
-      - checkout
+      - test
 
-      - run:
-          name: Which bundler?
-          command: bundle -v
-
-      - run:
-          name: Bundle Install
-          command: bundle install
-
-      - run:
-          name: Wait for PostgreSQL DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 2m
-
-      - run:
-          name: Wait for MySQL DB
-          command: dockerize -wait tcp://localhost:3306 -timeout 2m
-
-      - run:
-          name: Run rspec in parallel
-          command: |
-            bundle exec rspec --profile 10 \
-                              --format RspecJunitFormatter \
-                              --out test_results/rspec.xml \
-                              --format progress \
-                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-
-  ver6-0-0:
+  ver6-0:
     docker:
-      - image: circleci/ruby:2.6.3
+      - image: circleci/ruby:2.6.8
         environment:
           BUNDLE_PATH: vendor/bundle
-          AR_VERSION: ">= 6.0.0"
+          AR_VERSION: '~> 6.0.0'
           PG_VERSION: '~> 1.1'
           DB_HOST: 127.0.0.1
           DB_USER: root
@@ -131,32 +113,61 @@ jobs:
           MYSQL_DATABASE: database_consistency_test
 
     steps:
-      - checkout
+      - test
 
-      - run:
-          name: Which bundler?
-          command: bundle -v
+  ver6-1:
+    docker:
+      - image: circleci/ruby:2.6.8
+        environment:
+          BUNDLE_PATH: vendor/bundle
+          AR_VERSION: '~> 6.1.0'
+          PG_VERSION: '~> 1.1'
+          DB_HOST: 127.0.0.1
+          DB_USER: root
+          DB_PASSWORD: database_consistency_password
 
-      - run:
-          name: Bundle Install
-          command: bundle install
+      - image: circleci/postgres:9.6
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: database_consistency_test
+          POSTGRES_PASSWORD: database_consistency_password
 
-      - run:
-          name: Wait for PostgreSQL DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 2m
+      - image: circleci/mysql:5.6
+        environment:
+          MYSQL_ROOT_HOST: '%'
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: database_consistency_password
+          MYSQL_DATABASE: database_consistency_test
 
-      - run:
-          name: Wait for MySQL DB
-          command: dockerize -wait tcp://localhost:3306 -timeout 2m
+    steps:
+      - test
 
-      - run:
-          name: Run rspec in parallel
-          command: |
-            bundle exec rspec --profile 10 \
-                              --format RspecJunitFormatter \
-                              --out test_results/rspec.xml \
-                              --format progress \
-                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+  ver7-0:
+    docker:
+      - image: circleci/ruby:2.7.4
+        environment:
+          BUNDLE_PATH: vendor/bundle
+          AR_VERSION: '7.0.0.alpha2'
+          PG_VERSION: '~> 1.1'
+          DB_HOST: 127.0.0.1
+          DB_USER: root
+          DB_PASSWORD: database_consistency_password
+
+      - image: circleci/postgres:9.6
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: database_consistency_test
+          POSTGRES_PASSWORD: database_consistency_password
+
+      - image: circleci/mysql:5.6
+        environment:
+          MYSQL_ROOT_HOST: '%'
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: database_consistency_password
+          MYSQL_DATABASE: database_consistency_test
+
+    steps:
+      - test
 
 workflows:
   version: 2
@@ -164,4 +175,6 @@ workflows:
     jobs:
       - ver4-2
       - ver5-2
-      - ver6-0-0
+      - ver6-0
+      - ver6-1
+      - ver7-0


### PR DESCRIPTION
Done:
 - added Rails 6.1 and Rails 7.0 (pre-release) build jobs
 - fixed `>= 6.0.0` to `~> 6.0.0` to use 6.0.x, not latest Rails (see e.g. [this build](https://app.circleci.com/pipelines/github/djezzzl/database_consistency/181/workflows/e8177447-a7d9-4a38-8c37-2a51f24ae804/jobs/449))
 - extracted the common part in the build file
 - updated to more recent Ruby patch versions (2.6.3 -> 2.6.8, 2.5.5 -> 2.5.9)