### PR TITLE
Don't check column presence with has_one

### DIFF
--- a/lib/database_consistency/processors/validators_fractions_processor.rb
+++ b/lib/database_consistency/processors/validators_fractions_processor.rb
@@ -17,6 +17,7 @@ module DatabaseConsistency
 
           model._validators.flat_map do |attribute, validators|
             next unless attribute
+            next if model.reflect_on_association(attribute)&.has_one?
 
             enabled_checkers.map do |checker_class|
               checker = checker_class.new(model, attribute, validators)

--- a/spec/processors/validators_fractions_processor_spec.rb
+++ b/spec/processors/validators_fractions_processor_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe DatabaseConsistency::Processors::ValidatorsFractionsProcessor do
+  test_each_database do
+    subject(:processor) { described_class.new }
+
+    describe 'when has_one association is required' do
+      before do
+        define_database do
+          create_table :users
+        end
+
+        define_class('User', :users) do |klass|
+          klass.has_one :company
+          klass.validates :company, presence: true
+        end
+      end
+
+      specify do
+        expect(processor.reports).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Specifying `has_one :xxx, required: true` ([available in rails 6](https://www.rubydoc.info/docs/rails/6.0.2.1/ActiveRecord%2FAssociations%2FClassMethods:has_one))  adds a validator which fails the `ColumnPresenceChecker`

`:required` was [not yet available in rails 4](https://www.rubydoc.info/docs/rails/4.1.7/ActiveRecord%2FAssociations%2FClassMethods:has_one), yet it's possible to trigger this false positive by simply adding a presence checker.

I've excluded has-one-association-related attributes from the `ValidatorsFractionsProcessor`.