### PR TITLE
Allow to pass multiple config files

### DIFF
--- a/bin/database_consistency
+++ b/bin/database_consistency
@@ -1,25 +1,50 @@
 #!/usr/bin/env ruby
 
+require_relative '../lib/database_consistency/configuration'
+
+default_config = DatabaseConsistency::Configuration::DEFAULT_PATH
+
 if ARGV.include?('install')
-  require_relative '../lib/database_consistency/configuration'
-  config_filename = DatabaseConsistency::Configuration::CONFIGURATION_PATH
-  file_exists = File.exists?(config_filename)
+  require 'pathname'
+
+  file_exists = File.exists?(default_config)
   rules = Pathname.new(__FILE__).dirname.join('..', 'lib', 'database_consistency', 'templates', 'rails_defaults.yml').read
-  if file_exists && File.foreach(config_filename).grep(Regexp.new(rules.lines.first.chomp)).any?
-    puts "#{config_filename} is already present"
+  if file_exists && File.foreach(default_config).grep(Regexp.new(rules.lines.first.chomp)).any?
+    puts "#{default_config} is already present"
   else
-    File.open(config_filename, 'a') do |file|
+    File.open(default_config, 'a') do |file|
       file << "\n" * 2 if file_exists
       file << rules
     end
-    puts "#{config_filename} #{file_exists ? 'updated' : 'added'}"
+    puts "#{default_config} #{file_exists ? 'updated' : 'added'}"
   end
   exit 0
-else
-  base_dir = File.join(Dir.pwd, ARGV.first.to_s)
-  unless File.realpath(base_dir).start_with?(Dir.pwd)
-    puts "\nWarning! You are going out of current directory, ruby version may be wrong and some gems may be missing.\n"
+end
+
+require 'optparse'
+
+config = [default_config]
+opt_parser = OptionParser.new do |opts|
+  opts.banner = <<-DESC
+  Usage: database_consistency install - run installation
+         database_consistency [options]
+  DESC
+
+  opts.on('-cFILE', '--config=FILE', 'Use additional configuration file') do |f|
+    config << f
   end
+
+  opts.on('-h', '--help', 'Prints this help') do
+    puts opts
+    exit
+  end
+end
+
+opt_parser.parse!
+
+base_dir = File.join(Dir.pwd, ARGV.first.to_s)
+unless File.realpath(base_dir).start_with?(Dir.pwd)
+  puts "\nWarning! You are going out of current directory, ruby version may be wrong and some gems may be missing.\n"
 end
 
 # Load Rails project
@@ -41,5 +66,5 @@ $LOAD_PATH.unshift(File.expand_path('lib', __dir__))
 require 'database_consistency'
 
 # Process checks
-code = DatabaseConsistency.run
+code = DatabaseConsistency.run(config)
 exit code

--- a/lib/database_consistency.rb
+++ b/lib/database_consistency.rb
@@ -48,8 +48,8 @@ require 'database_consistency/processors/indexes_processor'
 # The root module
 module DatabaseConsistency
   class << self
-    def run
-      configuration = Configuration.new
+    def run(*args)
+      configuration = Configuration.new(*args)
       reports = Processors.reports(configuration)
 
       Writers::SimpleWriter.write(

--- a/rails6-example/.database_consistency.todo.yml
+++ b/rails6-example/.database_consistency.todo.yml
@@ -1,0 +1,4 @@
+Country:
+  users:
+    MissingIndexChecker:
+      enabled: false

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -86,4 +86,20 @@ RSpec.describe DatabaseConsistency::Configuration do
       include_examples 'checker', false
     end
   end
+
+  context 'when multiple files are given' do
+    subject(:configuration) do
+      described_class.new([
+        file_fixture('compact_checker_disabled.yml'),
+        file_fixture('todo.yml'),
+        file_fixture('todo_override.yml')
+      ])
+    end
+
+    it 'merges settings with last one given having the highest priority' do
+      expect(configuration).not_to be_enabled('User', 'email', 'ColumnPresenceChecker')
+      expect(configuration).not_to be_enabled('User', 'code', 'MissingIndexChecker')
+      expect(configuration).to be_enabled('User', 'code', 'NullConstraintChecker')
+    end
+  end
 end

--- a/spec/fixtures/files/todo.yml
+++ b/spec/fixtures/files/todo.yml
@@ -1,0 +1,6 @@
+User:
+  code:
+    NullConstraintChecker:
+      enabled: false
+    MissingIndexChecker:
+      enabled: false

--- a/spec/fixtures/files/todo_override.yml
+++ b/spec/fixtures/files/todo_override.yml
@@ -1,0 +1,4 @@
+User:
+  code:
+    NullConstraintChecker:
+      enabled: true


### PR DESCRIPTION
It's a common scenario to have a few configuration files - e.g. one is a convenient setup and the other is a list of temporarily disabled checks that are subject to fix (TODOs). 

This PR adds functionality to be able to use a few config files and documents how to do it.