### PR TITLE
Cover smaller types in ForeignKeyTypeChecker [PostgreSQL]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently, we can:
 - find missing length validations ([LengthConstraintChecker](#lengthconstraintchecker))
 - find missing presence validations ([NullConstraintChecker](#nullconstraintchecker))
 - find missing uniqueness validations ([UniqueIndexChecker](#uniqueindexchecker))
-- find missing foreign keys for `BelongsTo` associations ([ForeignKeyTypeChecker](#foreignkeychecker))
+- find missing foreign keys for `BelongsTo` associations ([ForeignKeyChecker](#foreignkeychecker))
 - find missing unique indexes for uniqueness validation ([MissingUniqueIndexChecker](#missinguniqueindexchecker))
 - find missing index for `HasOne` and `HasMany` associations ([MissingIndexChecker](#missingindexchecker))
 - find primary keys with integer/serial type ([PrimaryKeyTypeChecker](#primarykeytypechecker))

--- a/lib/database_consistency/checkers/association_checkers/foreign_key_type_checker.rb
+++ b/lib/database_consistency/checkers/association_checkers/foreign_key_type_checker.rb
@@ -6,15 +6,6 @@ module DatabaseConsistency
     class ForeignKeyTypeChecker < AssociationChecker
       INCONSISTENT_TYPE = 'associated model key (%a_f) with type (%a_t) mismatches key (%b_f) with type (%b_t)'
 
-      TYPES = {
-        'serial' => 'integer',
-        'integer' => 'integer',
-        'int' => 'integer',
-        'bigserial' => 'bigint',
-        'bigint' => 'bigint',
-        'bigint unsigned' => 'bigint unsigned'
-      }.freeze
-
       private
 
       # We skip check when:
@@ -37,7 +28,7 @@ module DatabaseConsistency
       # | consistent   | ok     |
       # | inconsistent | fail   |
       def check
-        if converted_type(base_column) == converted_type(associated_column)
+        if converted_type(associated_column).cover?(converted_type(base_column))
           report_template(:ok)
         else
           report_template(:fail, render_text)
@@ -116,9 +107,9 @@ module DatabaseConsistency
 
       # @param [ActiveRecord::ConnectionAdapters::Column]
       #
-      # @return [String]
+      # @return [DatabaseConsistency::Databases::Types::Base]
       def converted_type(column)
-        database_factory.type(type(column)).convert
+        database_factory.type(type(column))
       end
 
       # @return [Boolean]

--- a/lib/database_consistency/databases/types/base.rb
+++ b/lib/database_consistency/databases/types/base.rb
@@ -7,6 +7,10 @@ module DatabaseConsistency
       class Base
         attr_reader :type
 
+        COVERED_TYPES = {
+          'bigint' => %w[integer bigint]
+        }
+
         # @param [String] type
         def initialize(type)
           @type = type
@@ -15,6 +19,13 @@ module DatabaseConsistency
         # @return [String]
         def convert
           type
+        end
+
+        # @param [DatabaseConsistency::Databases::Types::Base]
+        #
+        # @return [Boolean]
+        def cover?(other_type)
+          (COVERED_TYPES[convert] || [convert]).include?(other_type.convert)
         end
       end
     end

--- a/spec/checkers/foreign_key_type_checker/postgresql_spec.rb
+++ b/spec/checkers/foreign_key_type_checker/postgresql_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, postgresql:
     context 'when base key has integer type' do
       let(:base_type) { :integer }
 
-      include_examples 'check matches', %i[serial], %i[bigserial]
+      include_examples 'check matches', %i[serial bigserial], %i[]
     end
 
     context 'when base key has bigint type' do
@@ -79,7 +79,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, postgresql:
     context 'when base key has serial type' do
       let(:base_type) { :serial }
 
-      include_examples 'check matches', %i[integer], %i[bigint]
+      include_examples 'check matches', %i[integer bigint], %i[]
     end
 
     context 'when base key has bigserial type' do
@@ -108,7 +108,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, postgresql:
     context 'when base key has serial type' do
       let(:base_type) { :serial }
 
-      include_examples 'check matches', %i[integer], %i[bigint]
+      include_examples 'check matches', %i[integer bigint], %i[]
     end
 
     context 'when base key has bigserial type' do
@@ -196,7 +196,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, postgresql:
     context 'when base key has serial type' do
       let(:base_type) { :serial }
 
-      include_examples 'check matches', %i[integer], %i[bigint]
+      include_examples 'check matches', %i[integer bigint], %i[]
     end
 
     context 'when base key has bigserial type' do
@@ -231,7 +231,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, postgresql:
     context 'when base key has integer type' do
       let(:base_type) { :integer }
 
-      include_examples 'check matches', %i[integer], %i[bigint]
+      include_examples 'check matches', %i[integer bigint], %i[]
     end
 
     context 'when base key has bigint type' do
@@ -266,7 +266,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, postgresql:
     context 'when base key has integer type' do
       let(:base_type) { :integer }
 
-      include_examples 'check matches', %i[integer], %i[bigint]
+      include_examples 'check matches', %i[integer bigint], %i[]
     end
 
     context 'when base key has bigint type' do
@@ -303,7 +303,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, postgresql:
     context 'when base key has integer type' do
       let(:base_type) { :integer }
 
-      include_examples 'check matches', %i[integer], %i[bigint]
+      include_examples 'check matches', %i[integer bigint], %i[]
     end
 
     context 'when base key has bigint type' do

--- a/spec/checkers/foreign_key_type_checker/sqlite_spec.rb
+++ b/spec/checkers/foreign_key_type_checker/sqlite_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, sqlite: tru
     context 'when base key has integer type' do
       let(:base_type) { :integer }
 
-      include_examples 'check matches', %i[serial], %i[bigserial]
+      include_examples 'check matches', %i[serial bigserial], %i[]
     end
 
     context 'when base key has bigint type' do
@@ -70,7 +70,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, sqlite: tru
     context 'when base key has serial type' do
       let(:base_type) { :serial }
 
-      include_examples 'check matches', %i[integer], %i[bigint]
+      include_examples 'check matches', %i[integer bigint], %i[]
     end
 
     context 'when base key has bigserial type' do
@@ -108,7 +108,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, sqlite: tru
     context 'when base key has serial type' do
       let(:base_type) { :serial }
 
-      include_examples 'check matches', %i[integer], %i[bigint]
+      include_examples 'check matches', %i[integer bigint], %i[]
     end
 
     context 'when base key has bigserial type' do


### PR DESCRIPTION
`bigint` is now default type used for all association columns in Rails. However, table that they refer to may be created long time ago and thus having `integer` primary key.
Since `bigint` is bigger type, it covers smaller `integer`. This PR disables warning about such fields