### PR TITLE
Configuration: use `YAML.safe_load_file` and allowing aliases (for Ruby 3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### [1.1.10] - 2022/01/06
+
+Improvements:
+- Allow aliases in YAML config file for Ruby 3.1
+
 ### [1.1.9] - 2021/12/29 
 
 - Fixed 1.1.8

--- a/lib/database_consistency/configuration.rb
+++ b/lib/database_consistency/configuration.rb
@@ -11,7 +11,7 @@ module DatabaseConsistency
       @configuration = Array(filepaths).each_with_object({}) do |filepath, result|
         content =
           if filepath && File.exist?(filepath)
-            data = YAML.load_file(filepath)
+            data = load_yaml_config_file(filepath)
             data.is_a?(Hash) ? data : {}
           else
             {}
@@ -52,6 +52,14 @@ module DatabaseConsistency
     private
 
     attr_reader :configuration
+
+    def load_yaml_config_file(filepath)
+      if YAML.respond_to?(:safe_load_file)
+        YAML.safe_load_file(filepath, aliases: true)
+      else
+        YAML.load_file(filepath)
+      end
+    end
 
     def combine_configs!(config, new_config)
       config.merge!(new_config) do |_key, val, new_val|

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe DatabaseConsistency::Configuration do
     end
   end
 
+  context 'with YAML alias' do
+    let(:file_path) { 'alias.yml' }
+
+    include_examples 'model', true
+    include_examples 'key', false
+    include_examples 'checker', false
+  end
+
   context 'when multiple files are given' do
     subject(:configuration) do
       described_class.new([

--- a/spec/fixtures/files/alias.yml
+++ b/spec/fixtures/files/alias.yml
@@ -1,0 +1,9 @@
+OnlyPresenceCheckerOnEmail: &only_presence_checker_on_email
+  email:
+    enabled: false
+    ColumnPresenceChecker:
+      enabled: true
+
+User:
+  enabled: true
+  <<: *only_presence_checker_on_email


### PR DESCRIPTION
By default, Ruby 3.1 will use `save_load_file` so we have to explicitly allow aliases

cf

> Psych 4.0 changes `Psych.load` as `safe_load` by the default. You may need to use Psych 3.3.2 for migrating to this behavior. [[Bug #17866](https://bugs.ruby-lang.org/issues/17866)]

in https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/