### PR TITLE
Skip EnumValueChecker for ActiveRecord < 7

### DIFF
--- a/lib/database_consistency/checkers/column_checkers/enum_value_checker.rb
+++ b/lib/database_consistency/checkers/column_checkers/enum_value_checker.rb
@@ -24,7 +24,7 @@ module DatabaseConsistency
       end
 
       def preconditions
-        Helper.postgresql? && column.type == :enum && (enum || inclusion_validator)
+        Helper.postgresql? && ActiveRecord::VERSION::MAJOR >= 6 && column.type == :enum && (enum || inclusion_validator)
       end
 
       def check

--- a/lib/database_consistency/checkers/column_checkers/enum_value_checker.rb
+++ b/lib/database_consistency/checkers/column_checkers/enum_value_checker.rb
@@ -24,7 +24,7 @@ module DatabaseConsistency
       end
 
       def preconditions
-        Helper.postgresql? && ActiveRecord::VERSION::MAJOR >= 6 && column.type == :enum && (enum || inclusion_validator)
+        Helper.postgresql? && ActiveRecord::VERSION::MAJOR >= 7 && column.type == :enum && (enum || inclusion_validator)
       end
 
       def check


### PR DESCRIPTION
`EnumValueChecker` precondition updated to not run for ActiveRecord version < 7.

This PR resolves issue #170