### PR TITLE
Fix deprecated File.exists? call which got removed in Ruby 3.2

### DIFF
--- a/bin/database_consistency
+++ b/bin/database_consistency
@@ -7,7 +7,7 @@ default_config = DatabaseConsistency::Configuration::DEFAULT_PATH
 if ARGV.include?('install')
   require 'pathname'
 
-  file_exists = File.exists?(default_config)
+  file_exists = File.exist?(default_config)
   rules = Pathname.new(__FILE__).dirname.join('..', 'lib', 'database_consistency', 'templates', 'rails_defaults.yml').read
   if file_exists && File.foreach(default_config).grep(Regexp.new(rules.lines.first.chomp)).any?
     puts "#{default_config} is already present"


### PR DESCRIPTION
The install task does not work on Ruby 3.2 right now:

```
❯ bundle exec database_consistency install
bundler: failed to load command: database_consistency (/Users/dennis/.asdf/installs/ruby/3.2.0/bin/database_consistency)
/Users/dennis/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/database_consistency-1.7.3/bin/database_consistency:10:in `<top (required)>': undefined method `exists?' for File:Class (NoMethodError)

  file_exists = File.exists?(default_config)
                    ^^^^^^^^
Did you mean?  exist?
```

`File.exists?` already [got deprecated in 2.1.0](https://bugs.ruby-lang.org/issues/17391) but [they only removed it in 3.2.0](https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2).