### PR TITLE
Fix parent_models method to return all parent models for the table

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,8 @@ jobs:
           - ruby-version: 'head'
             gemfile: 'gemfiles/ar_5_2.gemfile'
 
+    continue-on-error: ${{ contains(matrix.ruby-version, 'head') || contains(matrix.gemfile, 'ar_main') }}
+
     steps:
       - uses: actions/checkout@v3
 

--- a/lib/database_consistency/helper.rb
+++ b/lib/database_consistency/helper.rb
@@ -36,8 +36,8 @@ module DatabaseConsistency
 
     # Return list of not inherited models
     def parent_models
-      models.group_by(&:table_name).each_value.map do |models|
-        models.min_by { |model| models.include?(model.superclass) ? 1 : 0 }
+      models.group_by(&:table_name).each_value.flat_map do |models|
+        models.reject { |model| models.include?(model.superclass) }
       end
     end
 

--- a/spec/database_context.rb
+++ b/spec/database_context.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'openssl'
+
 RSpec.shared_context 'database context' do |configuration|
   before do
     ActiveRecord::Base.establish_connection(configuration)

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe DatabaseConsistency::Helper, :sqlite, :mysql, :postgresql do
-  subject { described_class.first_level_associations(child) }
-
   describe '#first_level_associations' do
+    subject { described_class.first_level_associations(child) }
+
     let(:parent) { Class.new(ActiveRecord::Base) { |klass| klass.has_one :user } }
 
     context 'when only parent defines association' do
@@ -14,6 +14,25 @@ RSpec.describe DatabaseConsistency::Helper, :sqlite, :mysql, :postgresql do
     context 'when child redefines association' do
       let(:child) { Class.new(parent) { |klass| klass.has_one :user } }
       it { expect(subject.size).to eq(1) }
+    end
+  end
+
+  describe '#parent_models' do
+    subject(:parent_models) { described_class.parent_models }
+
+    before do
+      allow(described_class).to receive(:project_klass?).and_return(true)
+
+      define_database_with_entity { |table| table.string :email }
+
+      define_class('Entities', :entities)
+      define_class('Scoped::Entities', :entities)
+      stub_const('SubEntities', Class.new(Entities))
+    end
+
+    it 'includes top-level classes only' do
+      expect(subject).to include(Entities, Scoped::Entities)
+      expect(subject).not_to include(SubEntities)
     end
   end
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe DatabaseConsistency::Helper, :sqlite, :mysql, :postgresql do
   describe '#first_level_associations' do
     subject { described_class.first_level_associations(child) }
 
-    let(:parent) { Class.new(ActiveRecord::Base) { |klass| klass.has_one :user } }
+    let(:parent) { define_class('Dummy') { |klass| klass.has_one :user } }
 
     context 'when only parent defines association' do
-      let(:child) { Class.new(parent) }
+      let(:child) { stub_const('SubDummy', Class.new(parent)) }
       it { is_expected.to eq([]) }
     end
 
     context 'when child redefines association' do
-      let(:child) { Class.new(parent) { |klass| klass.has_one :user } }
+      let(:child) { stub_const('SubDummy', Class.new(parent) { |klass| klass.has_one :user }) }
       it { expect(subject.size).to eq(1) }
     end
   end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe DatabaseConsistency::Helper, :sqlite, :mysql, :postgresql do
       define_class('Entities', :entities)
       define_class('Scoped::Entities', :entities)
       stub_const('SubEntities', Class.new(Entities))
+
+      allow(ActiveRecord::Base)
+        .to receive(:descendants)
+        .and_return([Entities, Scoped::Entities, SubEntities])
     end
 
     it 'includes top-level classes only' do


### PR DESCRIPTION
Until now, parent_models method was returning only one model from the root of the inheretance tree, but it might be a case some tables have 2 different top-level classes defined (e.g. for different contexts/engines/etc.). The class that was returned from `min_by` was actually determined by load order (an order of `descendants` method which actually changes definition between Ruby 3.0 and 3.2 on Rails 7)

In some cases it could be a breaking change as it might result in additional classes, that were accidentally skipped, violating some checks.    
