### PR TITLE
Fix undefined method error in ColumnPresenceChecker

### DIFF
--- a/lib/database_consistency/checkers/validators_fraction_checkers/column_presence_checker.rb
+++ b/lib/database_consistency/checkers/validators_fraction_checkers/column_presence_checker.rb
@@ -50,7 +50,7 @@ module DatabaseConsistency
         if association.polymorphic?
           reports << analyse(association.foreign_type.to_s, type: :association_foreign_type_missing_null_constraint)
         end
-        reports.compact!.presence
+        reports.compact.presence
       end
 
       def analyse(column_name, type:)

--- a/lib/database_consistency/checkers/validators_fraction_checkers/column_presence_checker.rb
+++ b/lib/database_consistency/checkers/validators_fraction_checkers/column_presence_checker.rb
@@ -38,19 +38,24 @@ module DatabaseConsistency
       end
 
       def check
-        return analyse(attribute.to_s, type: :null_constraint_missing) if regular_column
+        if regular_column
+          analyse(attribute.to_s, type: :null_constraint_missing)
+        else
+          analyse_association
+        end
+      end
 
+      def analyse_association
         reports = [analyse(association.foreign_key.to_s, type: :association_missing_null_constraint)]
         if association.polymorphic?
           reports << analyse(association.foreign_type.to_s, type: :association_foreign_type_missing_null_constraint)
         end
-
-        reports.compact!
-        reports.any? ? reports : nil
+        reports.compact!.presence
       end
 
       def analyse(column_name, type:)
         field = column(column_name)
+        # If the column is missing there is nothing we can do.
         return if field.nil?
 
         can_be_null = field.null

--- a/lib/database_consistency/checkers/validators_fraction_checkers/column_presence_checker.rb
+++ b/lib/database_consistency/checkers/validators_fraction_checkers/column_presence_checker.rb
@@ -45,11 +45,13 @@ module DatabaseConsistency
           reports << analyse(association.foreign_type.to_s, type: :association_foreign_type_missing_null_constraint)
         end
 
-        reports
+        reports.compact!
+        reports.any? ? reports : nil
       end
 
       def analyse(column_name, type:)
         field = column(column_name)
+        return if field.nil?
 
         can_be_null = field.null
         has_weak_option = weak_option?

--- a/spec/checkers/column_presence_checker_spec.rb
+++ b/spec/checkers/column_presence_checker_spec.rb
@@ -220,7 +220,6 @@ RSpec.describe DatabaseConsistency::Checkers::ColumnPresenceChecker, :sqlite, :m
       end
     end
 
-
     specify do
       expect(checker.report(catch_errors: false)).to be_nil
     end

--- a/spec/checkers/column_presence_checker_spec.rb
+++ b/spec/checkers/column_presence_checker_spec.rb
@@ -209,4 +209,20 @@ RSpec.describe DatabaseConsistency::Checkers::ColumnPresenceChecker, :sqlite, :m
       end
     end
   end
+
+  context 'when the column for the `belongs_to` foreign key is missing' do
+    let(:attribute) { :user }
+    let(:klass) { define_class { |klass| klass.belongs_to :user, foreign_key: 'user_id', **required } }
+
+    before do
+      define_database do
+        create_table :entities
+      end
+    end
+
+
+    specify do
+      expect(checker.report(catch_errors: false)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
ColumnPrensenceChecker was raising when the foreign_key column was missing in the database for a class.

Fixes #187 