### PR TITLE
Treat default cascade as restrict

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,30 +41,19 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version:
-          - '2.6'
-          - '2.7'
-          - '3.0'
-          - 'head'
-        gemfile:
-          - 'gemfiles/ar_4_2.gemfile'
-          - 'gemfiles/ar_5_2.gemfile'
-          - 'gemfiles/ar_6_0.gemfile'
-          - 'gemfiles/ar_6_1.gemfile'
-          - 'gemfiles/ar_main.gemfile'
-        exclude:
+        include:
           - ruby-version: '2.6'
-            gemfile: 'gemfiles/ar_main.gemfile'
+            gemfile: 'gemfiles/ar_4_2.gemfile'
           - ruby-version: '2.7'
-            gemfile: 'gemfiles/ar_4_2.gemfile'
-          - ruby-version: '3.0'
-            gemfile: 'gemfiles/ar_4_2.gemfile'
-          - ruby-version: '3.0'
             gemfile: 'gemfiles/ar_5_2.gemfile'
+          - ruby-version: '3.0'
+            gemfile: 'gemfiles/ar_6_0.gemfile'
+          - ruby-version: '3.1'
+            gemfile: 'gemfiles/ar_6_1.gemfile'
+          - ruby-version: '3.2'
+            gemfile: 'gemfiles/ar_7_0.gemfile'
           - ruby-version: 'head'
-            gemfile: 'gemfiles/ar_4_2.gemfile'
-          - ruby-version: 'head'
-            gemfile: 'gemfiles/ar_5_2.gemfile'
+            gemfile: 'gemfiles/ar_main.gemfile'
 
     continue-on-error: ${{ contains(matrix.ruby-version, 'head') || contains(matrix.gemfile, 'ar_main') }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # Ruby Version
 .ruby-version
+.ruby-gemset
 
 # Rails Example
 /rails-example/db/*.sqlite3

--- a/gemfiles/ar_7_0.gemfile
+++ b/gemfiles/ar_7_0.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 7.0.0'
+
+gemspec path: '../'

--- a/lib/database_consistency/checkers/association_checkers/foreign_key_cascade_checker.rb
+++ b/lib/database_consistency/checkers/association_checkers/foreign_key_cascade_checker.rb
@@ -14,11 +14,11 @@ module DatabaseConsistency
       )
 
       OPTION_TO_CASCADE = {
-        delete: :cascade,
-        delete_all: :cascade,
-        nullify: :nullify,
-        restrict_with_exception: :restrict,
-        restrict_with_error: :restrict
+        delete: [:cascade],
+        delete_all: [:cascade],
+        nullify: [:nullify],
+        restrict_with_exception: [nil, :restrict],
+        restrict_with_error: [nil, :restrict]
       }.freeze
 
       DEPENDENT_OPTIONS = OPTION_TO_CASCADE.keys.freeze
@@ -52,7 +52,7 @@ module DatabaseConsistency
       end
 
       def correlated_cascade_constraint?
-        required_foreign_key_cascade == foreign_key_on_delete_option
+        required_foreign_key_cascade.include?(foreign_key_on_delete_option)
       end
 
       def dependent_option

--- a/spec/checkers/foreign_key_cascade_checker_spec.rb
+++ b/spec/checkers/foreign_key_cascade_checker_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyCascadeChecker, :sqlite,
       end
     end
 
-    context 'when dependent option is missing' do
+    context 'when dependent option mismatches' do
       let!(:entity_class) do
         define_class('Entity', :entities) do |klass|
           klass.has_many :countries, dependent: :delete_all
@@ -43,6 +43,25 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyCascadeChecker, :sqlite,
           status: :fail,
           error_message: nil,
           error_slug: :missing_foreign_key_cascade
+        )
+      end
+    end
+
+    context 'when dependent option is missing' do
+      let!(:entity_class) do
+        define_class('Entity', :entities) do |klass|
+          klass.has_many :countries, dependent: :restrict_with_exception
+        end
+      end
+
+      specify do
+        expect(checker.report).to have_attributes(
+          checker_name: 'ForeignKeyCascadeChecker',
+          table_or_model_name: entity_class.name,
+          column_or_attribute_name: 'countries',
+          status: :ok,
+          error_message: nil,
+          error_slug: nil
         )
       end
     end


### PR DESCRIPTION
Fixes #186 
Also, I took a liberty of modernizing and speeding up the test suite. 
I think we can also drop Rails 4.2 and Ruby 2.6 but it is gonna be a breaking change with an according version bump so not today.