### PR TITLE
Fix pending message in `EnumTypeChecker` specs

### DIFF
--- a/spec/checkers/enum_type_checker/postgresql_spec.rb
+++ b/spec/checkers/enum_type_checker/postgresql_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe DatabaseConsistency::Checkers::EnumTypeChecker, :postgresql do
   subject(:checker) { described_class.new(model, enum) }
 
   before do
-    unless ActiveRecord::VERSION::MAJOR >= 7 && adapter == 'postgresql'
-      skip('older versions are not supported with sqlite3')
-    end
+    skip('older versions are not supported') if ActiveRecord::VERSION::MAJOR < 7
   end
 
   let(:model) { entity_class }

--- a/spec/checkers/enum_type_checker/postgresql_spec.rb
+++ b/spec/checkers/enum_type_checker/postgresql_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DatabaseConsistency::Checkers::EnumTypeChecker, :postgresql do
   let(:enum) { entity_class.defined_enums.keys.first }
   let!(:entity_class) do
     define_class do |klass|
-      klass.enum field: { value1: 'valueu1', value2: 'value2' }
+      klass.enum field: { value1: 'value1', value2: 'value2' }
     end
   end
 


### PR DESCRIPTION
No need to check for an adapter since we specified it in the metadata. Also, the message was incorrect.