### PR TITLE
Do not modify descendants in-place

### DIFF
--- a/lib/database_consistency/helper.rb
+++ b/lib/database_consistency/helper.rb
@@ -27,8 +27,9 @@ module DatabaseConsistency
 
     # Returns list of models to check
     def models
-      ActiveRecord::Base.descendants.delete_if(&:abstract_class?).select do |klass|
-        klass.connection.table_exists?(klass.table_name) &&
+      ActiveRecord::Base.descendants.select do |klass|
+        !klass.abstract_class? &&
+          klass.connection.table_exists?(klass.table_name) &&
           !klass.name.include?('HABTM_') &&
           project_klass?(klass)
       end


### PR DESCRIPTION
Hello,

I would like to support the following use-case, and am running into trouble because of this `delete_if`.

My use-case is the following:
- we have a code base where we do implement quite a few meta-programming tests, iterating over models and validating their associations or validations.
- we do also generate anonymous classes in our test suite, typically to test concerns
- which is causing flakiness depending on the ordering of the suite, when looking at `ActiveRecord::Base.descendants` to list all models
- so we came up with the following solution:
```ruby
# spec/support/descendants_memoizer.rb
module DescendantsMemoizer
  extend ActiveSupport::Concern

  class_methods do
    def descendants
      @descendants ||= super
    end
  end

  prepended do
    descendants # compute and memoize once and for all
  end
end

# spec/rails_helper.rb
ActiveRecord::Base.prepend(DescendantsMemoizer)
```

I wanted to be safe to be able to use `@descendants ||= super.freeze` to ensure it doesn't get modified in-place, and that's how I came out about this piece of code. Would you have anything against merging it in the subsequent `select`?
