### PR TITLE
Fix ForeignKeyTypeChecker when associated class has no table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,6 @@ if File.exist?(local_gemfile)
 else
   gem 'activerecord', ENV.fetch('AR_VERSION', '> 5')
   gem 'mysql2', ENV.fetch('MYSQL_VERSION', '~> 0.5')
-  gem 'pg', ENV.fetch('PG_VERSION', '~> 0.2')
+  gem 'pg', ENV.fetch('PG_VERSION', '>= 0.2')
   gem 'sqlite3', ENV.fetch('SQLITE_VERSION', '~> 1.3')
 end

--- a/lib/database_consistency/checkers/association_checkers/foreign_key_type_checker.rb
+++ b/lib/database_consistency/checkers/association_checkers/foreign_key_type_checker.rb
@@ -25,7 +25,8 @@ module DatabaseConsistency
         !association.polymorphic? &&
           association.through_reflection.nil? &&
           association.klass.present? &&
-          association.macro != :has_and_belongs_to_many
+          association.macro != :has_and_belongs_to_many &&
+          association.klass.table_exists?
       rescue NameError
         false
       end

--- a/spec/checkers/foreign_key_type_checker/postgresql_spec.rb
+++ b/spec/checkers/foreign_key_type_checker/postgresql_spec.rb
@@ -131,6 +131,20 @@ RSpec.describe DatabaseConsistency::Checkers::ForeignKeyTypeChecker, :postgresql
     end
   end
 
+  context 'when associated klass does not have table' do
+    let!(:company_class) { define_class('Company', :companies) { |klass| klass.belongs_to :user } }
+
+    before do
+      define_database do
+        create_table :companies
+      end
+    end
+
+    it 'outputs nothing' do
+      expect(checker.report).to be_nil
+    end
+  end
+
   context 'with has_one association' do
     let!(:company_class) do
       define_class('Company', :companies) do |klass|


### PR DESCRIPTION
Some gems bring `ActiveRecord` models with them and in some cases your own application doesn't even use them and might not even have required tables to use those models. `ForeignKeyTypeChecker` fails under those circumstances when it tries to load column data for the associated table.