### PR TITLE
Add support for rails 7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           - ruby-version: '3.1'
             gemfile: 'gemfiles/ar_6_1.gemfile'
           - ruby-version: '3.2'
-            gemfile: 'gemfiles/ar_7_0.gemfile'
+            gemfile: ['gemfiles/ar_7_0.gemfile', 'gemfiles/ar_7_1.gemfile']
           - ruby-version: 'head'
             gemfile: 'gemfiles/ar_main.gemfile'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,9 @@ jobs:
           - ruby-version: '3.1'
             gemfile: 'gemfiles/ar_6_1.gemfile'
           - ruby-version: '3.2'
-            gemfile: ['gemfiles/ar_7_0.gemfile', 'gemfiles/ar_7_1.gemfile']
+            gemfile: 'gemfiles/ar_7_0.gemfile'
+          - ruby-version: '3.2'
+            gemfile: 'gemfiles/ar_7_1.gemfile'
           - ruby-version: 'head'
             gemfile: 'gemfiles/ar_main.gemfile'
 

--- a/gemfiles/ar_7_1.gemfile
+++ b/gemfiles/ar_7_1.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 7.1.0'
+
+gemspec path: '../'

--- a/lib/database_consistency.rb
+++ b/lib/database_consistency.rb
@@ -81,7 +81,7 @@ require 'database_consistency/checkers/column_checkers/length_constraint_checker
 require 'database_consistency/checkers/column_checkers/primary_key_type_checker'
 require 'database_consistency/checkers/column_checkers/enum_value_checker'
 require 'database_consistency/checkers/column_checkers/three_state_boolean_checker'
-require 'database_consistency/checkers/column_checkers/implicit_ordering_checker.rb'
+require 'database_consistency/checkers/column_checkers/implicit_ordering_checker'
 
 require 'database_consistency/checkers/validator_checkers/validator_checker'
 require 'database_consistency/checkers/validator_checkers/missing_unique_index_checker'

--- a/lib/database_consistency/checkers/validators_fraction_checkers/column_presence_checker.rb
+++ b/lib/database_consistency/checkers/validators_fraction_checkers/column_presence_checker.rb
@@ -34,7 +34,23 @@ module DatabaseConsistency
       end
 
       def weak_option?
-        validators.all? { |validator| validator.options.slice(*WEAK_OPTIONS).any? }
+        validators.all? do |validator|
+          result = validator.options.slice(*WEAK_OPTIONS).any?
+
+          result = false if required_with_if?(validator)
+
+          result
+        end
+      end
+
+      def belongs_to_required_validates_foreign_key_disabled?
+        ActiveRecord.version >= Gem::Version.new('7.1.0') &&
+          !ActiveRecord.belongs_to_required_validates_foreign_key
+      end
+
+      def required_with_if?(validator)
+        belongs_to_required_validates_foreign_key_disabled? &&
+          validator.options[:message] == :required && validator.options[:if].present?
       end
 
       def check

--- a/spec/checkers/column_presence_checker_spec.rb
+++ b/spec/checkers/column_presence_checker_spec.rb
@@ -158,6 +158,25 @@ RSpec.describe DatabaseConsistency::Checkers::ColumnPresenceChecker, :sqlite, :m
     context 'when `belongs_to` is required' do
       let(:klass) { define_class { |klass| klass.belongs_to :user, **required } }
 
+      if ActiveRecord.version >= Gem::Version.new('7.1.0')
+        context 'when belongs_to_required_validates_foreign_key is set to false' do
+          specify do
+            old = ActiveRecord.belongs_to_required_validates_foreign_key
+            ActiveRecord.belongs_to_required_validates_foreign_key = false
+
+            expect(checker.report.first).to have_attributes(
+              checker_name: 'ColumnPresenceChecker',
+              table_or_model_name: klass.name,
+              column_or_attribute_name: 'user',
+              status: :fail,
+              error_message: nil,
+              error_slug: :association_missing_null_constraint
+            )
+
+            ActiveRecord.belongs_to_required_validates_foreign_key = old
+          end
+        end
+      end
       specify do
         expect(checker.report.first).to have_attributes(
           checker_name: 'ColumnPresenceChecker',
@@ -203,6 +222,19 @@ RSpec.describe DatabaseConsistency::Checkers::ColumnPresenceChecker, :sqlite, :m
 
     context 'when `belongs_to` is optional' do
       let(:klass) { define_class { |klass| klass.belongs_to :user, **optional } }
+
+      if ActiveRecord.version >= Gem::Version.new('7.1.0')
+        context 'when belongs_to_required_validates_foreign_key is set to false' do
+          specify do
+            old = ActiveRecord.belongs_to_required_validates_foreign_key
+            ActiveRecord.belongs_to_required_validates_foreign_key = false
+
+            expect(checker.report).to be_nil
+
+            ActiveRecord.belongs_to_required_validates_foreign_key = old
+          end
+        end
+      end
 
       specify do
         expect(checker.report).to be_nil

--- a/spec/checkers/column_presence_checker_spec.rb
+++ b/spec/checkers/column_presence_checker_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe DatabaseConsistency::Checkers::ColumnPresenceChecker, :sqlite, :m
           end
         end
       end
+
       specify do
         expect(checker.report.first).to have_attributes(
           checker_name: 'ColumnPresenceChecker',
@@ -217,6 +218,26 @@ RSpec.describe DatabaseConsistency::Checkers::ColumnPresenceChecker, :sqlite, :m
           error_message: nil,
           error_slug: nil
         )
+      end
+
+      if ActiveRecord.version >= Gem::Version.new('7.1.0')
+        context 'when belongs_to_required_validates_foreign_key is set to true' do
+          specify do
+            old = ActiveRecord.belongs_to_required_validates_foreign_key
+            ActiveRecord.belongs_to_required_validates_foreign_key = true
+
+            expect(checker.report.first).to have_attributes(
+              checker_name: 'ColumnPresenceChecker',
+              table_or_model_name: klass.name,
+              column_or_attribute_name: 'user',
+              status: :ok,
+              error_message: nil,
+              error_slug: nil
+            )
+
+            ActiveRecord.belongs_to_required_validates_foreign_key = old
+          end
+        end
       end
     end
 


### PR DESCRIPTION
fixes #215 

rails 7.1 recently added  this new default [configuration option](https://guides.rubyonrails.org/configuring.html#config-active-record-belongs-to-required-validates-foreign-key )

When set to false ( default in rails 7.1 ) an `if` option is added to the belongs_to option. which makes it not compatible with the current `WEAK_OPTIONS` array.

To cover this new case, and as a pre-check, we make sure that we're on rails 7.1.0 minimum as well as the ActiveRecord option ( `ActiveRecord.belongs_to_required_validates_foreign_key` ) is set to false to mitigate issues with real `if` conditions. We also check that the if condition is coupled with a `message` option set to `required`

This commit also adds rails 7.1 to the CI matrix.

cc @djezzzl @agrobbin
