### PR TITLE
Exclude anonymous classes from project classes

### DIFF
--- a/lib/database_consistency/helper.rb
+++ b/lib/database_consistency/helper.rb
@@ -63,6 +63,7 @@ module DatabaseConsistency
     # @return [Boolean]
     def project_klass?(klass)
       return true unless Module.respond_to?(:const_source_location) && defined?(Bundler)
+      return false if klass.name.nil?
 
       !Module.const_source_location(klass.to_s).first.to_s.include?(Bundler.bundle_path.to_s)
     end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -39,4 +39,23 @@ RSpec.describe DatabaseConsistency::Helper, :sqlite, :mysql, :postgresql do
       expect(subject).not_to include(SubEntities)
     end
   end
+
+  describe '#project_klass' do
+    subject(:project_klass) { described_class.project_klass?(klass) }
+
+    context 'when the class is anonymous' do
+      let(:klass) { Class.new }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the class is part of the project' do
+      let(:klass) { define_class }
+
+      before do
+        allow(Module).to receive(:const_source_location).with(klass.name).and_return([__FILE__, 1])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
 end


### PR DESCRIPTION
When anonymous classes are defined (most commonly in a previously required spec file), `DatabaseConsistency::Helper#project_klass?` fails with the following error: 
```
DatabaseConsistency::Helper#project_klass when the class is anonymous 
Failure/Error: !Module.const_source_location(klass.to_s).first.to_s.include?(Bundler.bundle_path.to_s)

NameError:
  wrong constant name #<Class:0x0000000104cb4b20>
```

This PR fixes the issue by excluding anonymous class from being considered project classes.

Thank you for this project! 🙏 