### PR TITLE
EnumValueChecker: Check enums in any order

### DIFF
--- a/lib/database_consistency/checkers/column_checkers/enum_value_checker.rb
+++ b/lib/database_consistency/checkers/column_checkers/enum_value_checker.rb
@@ -44,7 +44,7 @@ module DatabaseConsistency
       def verify_enum
         values = enum.values.uniq
 
-        if enum_column_values == values
+        if enum_column_values.sort == values.sort
           report_template(:ok, values)
         else
           report_template(:fail, values, error_slug: :enum_values_inconsistent_with_ar_enum)
@@ -54,7 +54,7 @@ module DatabaseConsistency
       def verify_inclusion_validator
         values = validator_values(inclusion_validator).uniq
 
-        if enum_column_values == values
+        if enum_column_values.sort == values.sort
           report_template(:ok, values)
         else
           report_template(:fail, values, error_slug: :enum_values_inconsistent_with_inclusion)

--- a/spec/checkers/enum_value_checker_spec.rb
+++ b/spec/checkers/enum_value_checker_spec.rb
@@ -76,7 +76,24 @@ RSpec.describe DatabaseConsistency::Checkers::EnumValueChecker, :postgresql do
     end
   end
 
-  context 'when validation values are inconsistent' do
+  context 'when validation values are out of order' do
+    let(:klass) { define_class { |klass| klass.validates :status, inclusion: { in: %w[value2 value1] } } }
+
+    specify do
+      expect(checker.report.first).to have_attributes(
+        checker_name: 'EnumValueChecker',
+        table_or_model_name: klass.name,
+        column_or_attribute_name: 'status',
+        status: :ok,
+        error_slug: nil,
+        enum_values: %w[value1 value2],
+        declared_values: %w[value2 value1],
+        error_message: nil
+      )
+    end
+  end
+
+  context 'when enum values are inconsistent' do
     let(:klass) { define_class { |klass| klass.enum :status, { value1: 'value1', something: 'something' } } }
 
     specify do
@@ -88,6 +105,23 @@ RSpec.describe DatabaseConsistency::Checkers::EnumValueChecker, :postgresql do
         error_slug: :enum_values_inconsistent_with_ar_enum,
         enum_values: %w[value1 value2],
         declared_values: %w[value1 something],
+        error_message: nil
+      )
+    end
+  end
+
+  context 'when enum values are out of order' do
+    let(:klass) { define_class { |klass| klass.enum :status, { value2: 'value2', value1: 'value1' } } }
+
+    specify do
+      expect(checker.report.first).to have_attributes(
+        checker_name: 'EnumValueChecker',
+        table_or_model_name: klass.name,
+        column_or_attribute_name: 'status',
+        status: :ok,
+        error_slug: nil,
+        enum_values: %w[value1 value2],
+        declared_values: %w[value2 value1],
         error_message: nil
       )
     end


### PR DESCRIPTION
👋

I have recently enabled the `EnumValueChecker` in our project and noticed that several enum declarations were flagged as inconsistent. This is because our ActiveRecord models' enum declarations do not always match the exact order in PostgreSQL.

I propose that strict literal consistency in this checker may be unnecessary, and this PR addresses that concern.

Looking forward to the feedback.

Thank you!