### PR TITLE
Fix database settings handling (issue #226)

### DIFF
--- a/lib/database_consistency/configuration.rb
+++ b/lib/database_consistency/configuration.rb
@@ -48,6 +48,12 @@ module DatabaseConsistency
       value
     end
 
+    def database_enabled?(name)
+      value = configuration.dig('DatabaseConsistencyDatabases', name, 'enabled')
+
+      value.nil? ? true : value
+    end
+
     private
 
     attr_reader :configuration

--- a/lib/database_consistency/processors/associations_processor.rb
+++ b/lib/database_consistency/processors/associations_processor.rb
@@ -14,11 +14,10 @@ module DatabaseConsistency
 
       private
 
-      def check # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def check # rubocop:disable Metrics/MethodLength
         Helper.models.flat_map do |model|
           DebugContext.with(model: model.name) do
-            next unless configuration.enabled?('DatabaseConsistencyDatabases', Helper.database_name(model)) &&
-                        configuration.enabled?(model.name.to_s)
+            next unless model_enabled?(model)
 
             Helper.first_level_associations(model).flat_map do |association|
               DebugContext.with(association: association.name) do

--- a/lib/database_consistency/processors/base_processor.rb
+++ b/lib/database_consistency/processors/base_processor.rb
@@ -43,6 +43,11 @@ module DatabaseConsistency
 
       private
 
+      def model_enabled?(model)
+        configuration.database_enabled?(Helper.database_name(model)) &&
+          configuration.enabled?(model.name.to_s)
+      end
+
       def check
         raise NotImplementedError
       end

--- a/lib/database_consistency/processors/columns_processor.rb
+++ b/lib/database_consistency/processors/columns_processor.rb
@@ -15,11 +15,10 @@ module DatabaseConsistency
 
       private
 
-      def check # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def check # rubocop:disable Metrics/MethodLength
         Helper.parent_models.flat_map do |model|
           DebugContext.with(model: model.name) do
-            next unless configuration.enabled?('DatabaseConsistencyDatabases', Helper.database_name(model)) &&
-                        configuration.enabled?(model.name.to_s)
+            next unless model_enabled?(model)
 
             model.columns.flat_map do |column|
               DebugContext.with(column: column.name) do

--- a/lib/database_consistency/processors/enums_processor.rb
+++ b/lib/database_consistency/processors/enums_processor.rb
@@ -10,11 +10,10 @@ module DatabaseConsistency
 
       private
 
-      def check # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def check # rubocop:disable Metrics/MethodLength
         Helper.models.flat_map do |model|
           DebugContext.with(model: model.name) do
-            next unless configuration.enabled?('DatabaseConsistencyDatabases', Helper.database_name(model)) &&
-                        configuration.enabled?(model.name.to_s)
+            next unless model_enabled?(model)
 
             model.defined_enums.keys.flat_map do |enum|
               DebugContext.with(enum: enum) do

--- a/lib/database_consistency/processors/indexes_processor.rb
+++ b/lib/database_consistency/processors/indexes_processor.rb
@@ -15,8 +15,7 @@ module DatabaseConsistency
       def check # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         Helper.parent_models.flat_map do |model|
           DebugContext.with(model: model.name) do
-            next unless configuration.enabled?('DatabaseConsistencyDatabases', Helper.database_name(model)) &&
-                        configuration.enabled?(model.name.to_s)
+            next unless model_enabled?(model)
 
             indexes = model.connection.indexes(model.table_name)
 

--- a/lib/database_consistency/processors/models_processor.rb
+++ b/lib/database_consistency/processors/models_processor.rb
@@ -10,11 +10,10 @@ module DatabaseConsistency
 
       private
 
-      def check # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def check
         Helper.project_models.flat_map do |model|
           DebugContext.with(model: model.name) do
-            next unless configuration.enabled?('DatabaseConsistencyDatabases', Helper.database_name(model)) &&
-                        configuration.enabled?(model.name.to_s)
+            next unless model_enabled?(model)
 
             enabled_checkers.flat_map do |checker_class|
               DebugContext.with(checker: checker_class) do

--- a/lib/database_consistency/processors/validators_fractions_processor.rb
+++ b/lib/database_consistency/processors/validators_fractions_processor.rb
@@ -11,11 +11,10 @@ module DatabaseConsistency
       private
 
       # @return [Array<Hash>]
-      def check # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def check # rubocop:disable Metrics/MethodLength
         Helper.parent_models.flat_map do |model|
           DebugContext.with(model: model.name) do
-            next unless configuration.enabled?('DatabaseConsistencyDatabases', Helper.database_name(model)) &&
-                        configuration.enabled?(model.name.to_s)
+            next unless model_enabled?(model)
 
             model._validators.flat_map do |attribute, validators|
               DebugContext.with(attribute: attribute) do

--- a/lib/database_consistency/processors/validators_processor.rb
+++ b/lib/database_consistency/processors/validators_processor.rb
@@ -12,11 +12,10 @@ module DatabaseConsistency
       private
 
       # @return [Array<Hash>]
-      def check # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
+      def check # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         Helper.parent_models.flat_map do |model|
           DebugContext.with(model: model.name) do
-            next unless configuration.enabled?('DatabaseConsistencyDatabases', Helper.database_name(model)) &&
-                        configuration.enabled?(model.name.to_s)
+            next unless model_enabled?(model)
 
             model.validators.flat_map do |validator|
               next unless validator.respond_to?(:attributes)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,6 +3,14 @@
 RSpec.describe DatabaseConsistency::Configuration, :sqlite, :mysql, :postgresql do
   subject(:configuration) { described_class.new(file_fixture(file_path)) }
 
+  shared_examples 'db settings' do |value|
+    context 'database' do
+      specify do
+        expect(configuration.database_enabled?('primary')).to eq(value)
+      end
+    end
+  end
+
   shared_examples 'checker' do |value|
     context 'checker' do
       specify do
@@ -98,6 +106,7 @@ RSpec.describe DatabaseConsistency::Configuration, :sqlite, :mysql, :postgresql 
   context 'with all option enabled' do
     let(:file_path) { 'all_enabled.yml' }
 
+    include_examples 'db settings', true
     include_examples 'global checker', true
     include_examples 'model', true
     include_examples 'key', true
@@ -107,6 +116,7 @@ RSpec.describe DatabaseConsistency::Configuration, :sqlite, :mysql, :postgresql 
   context 'with all option disabled' do
     let(:file_path) { 'all_disabled.yml' }
 
+    include_examples 'db settings', true
     include_examples 'global checker', true
     include_examples 'model', false
     include_examples 'key', false


### PR DESCRIPTION
Previously DatabaseConsistencyCheckers\All\disabled settings prevented all checkers from working by affecting base DB settings