### PR TITLE
Make LengthConstraintChecker ignore Proc/Symbol settings

### DIFF
--- a/lib/database_consistency/checkers/column_checkers/length_constraint_checker.rb
+++ b/lib/database_consistency/checkers/column_checkers/length_constraint_checker.rb
@@ -45,8 +45,14 @@ module DatabaseConsistency
       end
 
       def valid?(sign)
-        %i[maximum is].each do |option|
-          return validator.options[option].public_send(sign, column.limit) if validator.options[option]
+        %i[maximum is].each do |key|
+          option = validator.options[key]
+          next unless option
+
+          # skipping runtime-calculated limits
+          return true if option.is_a?(Proc) || option.is_a?(Symbol)
+
+          return option.public_send(sign, column.limit)
         end
 
         false

--- a/spec/checkers/length_constraint_checker_spec.rb
+++ b/spec/checkers/length_constraint_checker_spec.rb
@@ -10,8 +10,27 @@ RSpec.describe DatabaseConsistency::Checkers::LengthConstraintChecker, :sqlite, 
     define_database_with_entity { |table| table.string :email, limit: 256 }
   end
 
-  context 'when validation is missing' do
+  context 'when validation is present' do
     let(:klass) { define_class { |klass| klass.validates :email, length: { maximum: 256 } } }
+
+    specify do
+      expect(checker.report).to have_attributes(
+        checker_name: 'LengthConstraintChecker',
+        table_or_model_name: klass.name,
+        column_or_attribute_name: 'email',
+        status: :ok,
+        error_slug: nil,
+        error_message: nil
+      )
+    end
+  end
+
+  context 'when validation is proc' do
+    before do
+      skip('AR 4 doesnt support Proc') if ActiveRecord::VERSION::MAJOR < 5
+    end
+
+    let(:klass) { define_class { |klass| klass.validates :email, length: { maximum: proc { |_| 256 } } } }
 
     specify do
       expect(checker.report).to have_attributes(


### PR DESCRIPTION
`maximum`/`is` options could possible be Proc or Symbol or whatever else responding to `call`

https://github.com/rails/rails/blob/main/activemodel/lib/active_model/validations/resolve_value.rb#L6

However we are interested in numeric values only, so skipping procs and symbols