### PR TITLE
Handle lower() index in autofix migration writer (issue #224)

### DIFF
--- a/lib/database_consistency/writers/autofix/association_missing_index.rb
+++ b/lib/database_consistency/writers/autofix/association_missing_index.rb
@@ -23,7 +23,13 @@ module DatabaseConsistency
         end
 
         def columns
-          "%w[#{report.columns.join(' ')}]"
+          if report.columns.size > 1
+            "%w[#{report.columns.join(' ')}]"
+          elsif report.columns.first =~ /[()]/
+            "'#{report.columns.first}'"
+          else
+            ":#{report.columns.first}"
+          end
         end
 
         def columns_key


### PR DESCRIPTION
Use `%w[]` for arrays, `''` for SQL functions (detected by `(` or `)` presence) and symbols for everything else