### PR TITLE
Fixup compatibility w/ `active_type` gem

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+customize_gemfiles do
+  {
+    single_quotes: true,
+    heading: <<~HEADING
+      frozen_string_literal: true
+    HEADING
+  }
+end
+
+appraise 'ar_4_2' do
+  remove_gem 'appraisal'
+  gem 'activerecord', '~> 4.2.0'
+  gem 'mysql2', '~> 0.4.0'
+  gem 'pg', '~> 0.2'
+  gem 'sqlite3', '~> 1.3.9'
+end
+
+%w[5.2 6.0 6.1 7.0 7.1].each do |version|
+  appraise "ar_#{version.gsub('.', '_')}" do
+    remove_gem 'appraisal'
+    gem 'activerecord', "~> #{version}.0"
+    gem 'sqlite3', '~> 1.3'
+  end
+end
+
+appraise 'ar_main' do
+  remove_gem 'appraisal'
+  gem 'activerecord', git: 'https://github.com/rails/rails', branch: 'main'
+  gem 'sqlite3', '>= 2.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,11 @@ local_gemfile = 'Gemfile.local'
 if File.exist?(local_gemfile)
   eval(File.read(local_gemfile)) # rubocop:disable Security/Eval
 else
+  # https://github.com/thoughtbot/appraisal/commit/830d47eb8a4d8ca5b5714155811c64b410cf43fe
+  gem 'appraisal', github: 'thoughtbot/appraisal'
+
   gem 'activerecord', ENV.fetch('AR_VERSION', '> 5')
   gem 'mysql2', ENV.fetch('MYSQL_VERSION', '~> 0.5')
   gem 'pg', ENV.fetch('PG_VERSION', '>= 0.2')
-  gem 'sqlite3', ENV.fetch('SQLITE_VERSION', '~> 1.3')
+  gem 'sqlite3', ENV.fetch('SQLITE_VERSION', '> 1.3')
 end

--- a/database_consistency.gemspec
+++ b/database_consistency.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
   spec.add_development_dependency 'rubocop', '~> 0.55'
-  spec.add_development_dependency 'sqlite3', '~> 1.3'
+  spec.add_development_dependency 'sqlite3', '> 1.3'
 end

--- a/gemfiles/ar_5_2.gemfile
+++ b/gemfiles/ar_5_2.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.2.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_6_0.gemfile
+++ b/gemfiles/ar_6_0.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 6.0.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_6_1.gemfile
+++ b/gemfiles/ar_6_1.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 6.1.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_7_0.gemfile
+++ b/gemfiles/ar_7_0.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 7.0.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_7_1.gemfile
+++ b/gemfiles/ar_7_1.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 7.1.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_main.gemfile
+++ b/gemfiles/ar_main.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', git: 'https://github.com/rails/rails', branch: 'main'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '>= 2.0'
 
 gemspec path: '../'

--- a/lib/database_consistency/helper.rb
+++ b/lib/database_consistency/helper.rb
@@ -65,6 +65,8 @@ module DatabaseConsistency
       return true unless Module.respond_to?(:const_source_location) && defined?(Bundler)
 
       !Module.const_source_location(klass.to_s).first.to_s.include?(Bundler.bundle_path.to_s)
+    rescue NameError
+      false
     end
 
     # @return [Boolean]

--- a/lib/database_consistency/helper.rb
+++ b/lib/database_consistency/helper.rb
@@ -39,7 +39,7 @@ module DatabaseConsistency
     def models
       project_models.select do |klass|
         !klass.abstract_class? &&
-          klass.connection.table_exists?(klass.table_name) &&
+          klass.table_exists? &&
           !klass.name.include?('HABTM_')
       end
     end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -39,4 +39,24 @@ RSpec.describe DatabaseConsistency::Helper, :sqlite, :mysql, :postgresql do
       expect(subject).not_to include(SubEntities)
     end
   end
+
+  describe '#project_klass', focus: true do
+    subject(:project_klass) { described_class.project_klass?(klass) }
+
+    # `Module.const_source_location` was added in Ruby-2.7, so on previous Ruby versions we always
+    #   return `true` instead of `false` expected for this testcases
+    context 'when the class is anonymous' do
+      let(:klass) { define_class.tap { |k| k.singleton_class.remove_method(:name) } }
+
+      context 'without a name' do
+        it { is_expected.to be(RUBY_VERSION < '2.7') }
+      end
+
+      context 'with bogus name' do
+        before { klass.define_singleton_method(:name) { 'Some invalid !@#' } }
+
+        it { is_expected.to be(RUBY_VERSION < '2.7') }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Handle anonymous classes (a bit differently than https://github.com/djezzzl/database_consistency/pull/221) and use `.table_exists?` on Model instead of `Model.connection`. 
See commit messages for details.
This is arguable ActiveType issue, but why not handle such cases.

Also fixing compat w/ AR-main, also extracted to the separate PR https://github.com/djezzzl/database_consistency/pull/235 to allow  merging separately if needed.