### PR TITLE
Fixup ActiveRecord main workflow

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+customize_gemfiles do
+  {
+    single_quotes: true,
+    heading: <<~HEADING
+      frozen_string_literal: true
+    HEADING
+  }
+end
+
+appraise 'ar_4_2' do
+  remove_gem 'appraisal'
+  gem 'activerecord', '~> 4.2.0'
+  gem 'mysql2', '~> 0.4.0'
+  gem 'pg', '~> 0.2'
+  gem 'sqlite3', '~> 1.3.9'
+end
+
+%w[5.2 6.0 6.1 7.0 7.1].each do |version|
+  appraise "ar_#{version.gsub('.', '_')}" do
+    remove_gem 'appraisal'
+    gem 'activerecord', "~> #{version}.0"
+    gem 'sqlite3', '~> 1.3'
+  end
+end
+
+appraise 'ar_main' do
+  remove_gem 'appraisal'
+  gem 'activerecord', git: 'https://github.com/rails/rails', branch: 'main'
+  gem 'sqlite3', '>= 2.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,11 @@ local_gemfile = 'Gemfile.local'
 if File.exist?(local_gemfile)
   eval(File.read(local_gemfile)) # rubocop:disable Security/Eval
 else
+  # https://github.com/thoughtbot/appraisal/commit/830d47eb8a4d8ca5b5714155811c64b410cf43fe
+  gem 'appraisal', github: 'thoughtbot/appraisal'
+
   gem 'activerecord', ENV.fetch('AR_VERSION', '> 5')
   gem 'mysql2', ENV.fetch('MYSQL_VERSION', '~> 0.5')
   gem 'pg', ENV.fetch('PG_VERSION', '>= 0.2')
-  gem 'sqlite3', ENV.fetch('SQLITE_VERSION', '~> 1.3')
+  gem 'sqlite3', ENV.fetch('SQLITE_VERSION', '> 1.3')
 end

--- a/database_consistency.gemspec
+++ b/database_consistency.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
   spec.add_development_dependency 'rubocop', '~> 0.55'
-  spec.add_development_dependency 'sqlite3', '~> 1.3'
+  spec.add_development_dependency 'sqlite3', '> 1.3'
 end

--- a/gemfiles/ar_5_2.gemfile
+++ b/gemfiles/ar_5_2.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.2.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_6_0.gemfile
+++ b/gemfiles/ar_6_0.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 6.0.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_6_1.gemfile
+++ b/gemfiles/ar_6_1.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 6.1.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_7_0.gemfile
+++ b/gemfiles/ar_7_0.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 7.0.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_7_1.gemfile
+++ b/gemfiles/ar_7_1.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 7.1.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
 
 gemspec path: '../'

--- a/gemfiles/ar_main.gemfile
+++ b/gemfiles/ar_main.gemfile
@@ -3,5 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', git: 'https://github.com/rails/rails', branch: 'main'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '>= 2.0'
 
 gemspec path: '../'


### PR DESCRIPTION
Rails switched to `sqlite3 >= 2.0` in [0], so workflow fails due to the current `~> 1.3` constraint. It's quite complicated to make current gemfiles setup to handle this, because `sqlite3` is not an AR dependency, but loaded when needed, so we need to edit all the gemfiles with explicit sqlite3 constraint.
Introduce Appraisal to generate gemfiles, so it's easier to handle.

[0] https://github.com/rails/rails/commit/2976d3767e6572ee1838b50b5f401983918f99c7