### PR TITLE
Proposal: Change autofix to use the migration context from the migration connection pool

### DIFF
--- a/lib/database_consistency/writers/autofix/helpers/migration.rb
+++ b/lib/database_consistency/writers/autofix/helpers/migration.rb
@@ -6,7 +6,7 @@ module DatabaseConsistency
       module Helpers
         module Migration # :nodoc:
           def migration_path(name)
-            migration_context = ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool.migration_context
+            migration_context = ActiveRecord::Base.connection.migration_context
 
             last = migration_context.migrations.last
             version = ActiveRecord::Migration.next_migration_number(last&.version.to_i + 1)

--- a/lib/database_consistency/writers/autofix/helpers/migration.rb
+++ b/lib/database_consistency/writers/autofix/helpers/migration.rb
@@ -6,10 +6,9 @@ module DatabaseConsistency
       module Helpers
         module Migration # :nodoc:
           def migration_path(name)
-            migration_paths  = ActiveRecord::Migrator.migrations_paths
-            schema_migration = ActiveRecord::Base.connection.schema_migration
+            migration_context = ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool.migration_context
 
-            last = ActiveRecord::MigrationContext.new(migration_paths, schema_migration).migrations.last
+            last = migration_context.migrations.last
             version = ActiveRecord::Migration.next_migration_number(last&.version.to_i + 1)
 
             "db/migrate/#{version}_#{name.underscore}.rb"


### PR DESCRIPTION
This is a proposal to change the auto fix `migration_path` method to use `ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool` to get the migration context.

This fixes cases where a given ConnectionAdapter does not implement `schema_migration`, such as `PostGISAdapter` which blow up with 

```
lib/database_consistency/writers/autofix/helpers/migration.rb:10:in `migration_path': undefined method `schema_migration' for an instance of ActiveRecord::ConnectionAdapters::PostGISAdapter (NoMethodError)
```

I can't install mysql versions to run the appraisals (getting lots of compilation errors when bundling) so Im not sure if this passes tests for all supported versions