### PR TITLE
Allow custom checkers

### DIFF
--- a/lib/database_consistency.rb
+++ b/lib/database_consistency.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'active_record'
+require 'active_support/inflector'
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.irregular 'index', 'indexes'
+end
 
 require 'database_consistency/version'
 require 'database_consistency/helper'
@@ -60,6 +65,15 @@ require 'database_consistency/databases/factory'
 require 'database_consistency/databases/types/base'
 require 'database_consistency/databases/types/sqlite'
 
+require 'database_consistency/processors/base_processor'
+require 'database_consistency/processors/enums_processor'
+require 'database_consistency/processors/associations_processor'
+require 'database_consistency/processors/validators_processor'
+require 'database_consistency/processors/columns_processor'
+require 'database_consistency/processors/validators_fractions_processor'
+require 'database_consistency/processors/indexes_processor'
+require 'database_consistency/processors/models_processor'
+
 require 'database_consistency/checkers/base_checker'
 
 require 'database_consistency/checkers/enum_checkers/enum_checker'
@@ -94,15 +108,6 @@ require 'database_consistency/checkers/index_checkers/index_checker'
 require 'database_consistency/checkers/index_checkers/unique_index_checker'
 require 'database_consistency/checkers/index_checkers/redundant_index_checker'
 require 'database_consistency/checkers/index_checkers/redundant_unique_index_checker'
-
-require 'database_consistency/processors/base_processor'
-require 'database_consistency/processors/enums_processor'
-require 'database_consistency/processors/associations_processor'
-require 'database_consistency/processors/validators_processor'
-require 'database_consistency/processors/columns_processor'
-require 'database_consistency/processors/validators_fractions_processor'
-require 'database_consistency/processors/indexes_processor'
-require 'database_consistency/processors/models_processor'
 
 # The root module
 module DatabaseConsistency

--- a/lib/database_consistency/checkers/base_checker.rb
+++ b/lib/database_consistency/checkers/base_checker.rb
@@ -11,9 +11,19 @@ module DatabaseConsistency
         configuration.enabled?('DatabaseConsistencyCheckers', checker_name)
       end
 
+      def self.inherited(subclass)
+        super
+
+        return if subclass.superclass.name == 'DatabaseConsistency::Checkers::BaseChecker'
+
+        processor_prefix = subclass.superclass.name.demodulize.delete_suffix('Checker').pluralize
+        processor = "DatabaseConsistency::Processors::#{processor_prefix}Processor".constantize
+        processor.checkers << subclass
+      end
+
       # @return [String]
       def self.checker_name
-        @checker_name ||= name.split('::').last
+        @checker_name ||= name.demodulize
       end
 
       # @param [Boolean] catch_errors

--- a/lib/database_consistency/configuration.rb
+++ b/lib/database_consistency/configuration.rb
@@ -16,6 +16,8 @@ module DatabaseConsistency
         end
         extract_configurations(existing_paths)
       end
+
+      load_custom_checkers
     end
 
     def debug?
@@ -122,6 +124,14 @@ module DatabaseConsistency
         else
           settings && settings['log_level']
         end
+    end
+
+    def load_custom_checkers
+      return unless configuration.key?('require') && configuration['require'].is_a?(Array)
+
+      configuration['require'].each do |path|
+        require path
+      end
     end
   end
 end

--- a/lib/database_consistency/processors/associations_processor.rb
+++ b/lib/database_consistency/processors/associations_processor.rb
@@ -4,14 +4,6 @@ module DatabaseConsistency
   module Processors
     # The class to process associations
     class AssociationsProcessor < BaseProcessor
-      CHECKERS = [
-        Checkers::MissingIndexChecker,
-        Checkers::ForeignKeyChecker,
-        Checkers::ForeignKeyTypeChecker,
-        Checkers::ForeignKeyCascadeChecker,
-        Checkers::MissingAssociationClassChecker
-      ].freeze
-
       private
 
       def check # rubocop:disable Metrics/MethodLength

--- a/lib/database_consistency/processors/base_processor.rb
+++ b/lib/database_consistency/processors/base_processor.rb
@@ -4,21 +4,17 @@ module DatabaseConsistency
   # The module for processors
   module Processors
     def self.reports(configuration)
-      [
-        ColumnsProcessor,
-        ValidatorsProcessor,
-        AssociationsProcessor,
-        ValidatorsFractionsProcessor,
-        IndexesProcessor,
-        EnumsProcessor,
-        ModelsProcessor
-      ].flat_map do |processor|
+      BaseProcessor.descendants.flat_map do |processor|
         processor.new(configuration).reports
       end
     end
 
     # The base class for processors
     class BaseProcessor
+      def self.checkers
+        @checkers ||= Set.new
+      end
+
       attr_reader :configuration
 
       # @param [DatabaseConsistency::Configuration] configuration
@@ -38,7 +34,7 @@ module DatabaseConsistency
 
       # @return [Array<Class>]
       def enabled_checkers
-        self.class::CHECKERS.select { |checker| checker.enabled?(configuration) }
+        self.class.checkers.select { |checker| checker.enabled?(configuration) }
       end
 
       private

--- a/lib/database_consistency/processors/columns_processor.rb
+++ b/lib/database_consistency/processors/columns_processor.rb
@@ -4,15 +4,6 @@ module DatabaseConsistency
   module Processors
     # The class to process columns
     class ColumnsProcessor < BaseProcessor
-      CHECKERS = [
-        Checkers::NullConstraintChecker,
-        Checkers::LengthConstraintChecker,
-        Checkers::PrimaryKeyTypeChecker,
-        Checkers::EnumValueChecker,
-        Checkers::ThreeStateBooleanChecker,
-        Checkers::ImplicitOrderingChecker
-      ].freeze
-
       private
 
       def check # rubocop:disable Metrics/MethodLength

--- a/lib/database_consistency/processors/enums_processor.rb
+++ b/lib/database_consistency/processors/enums_processor.rb
@@ -4,10 +4,6 @@ module DatabaseConsistency
   module Processors
     # The class to process enums
     class EnumsProcessor < BaseProcessor
-      CHECKERS = [
-        Checkers::EnumTypeChecker
-      ].freeze
-
       private
 
       def check # rubocop:disable Metrics/MethodLength

--- a/lib/database_consistency/processors/indexes_processor.rb
+++ b/lib/database_consistency/processors/indexes_processor.rb
@@ -4,12 +4,6 @@ module DatabaseConsistency
   module Processors
     # The class to process indexes
     class IndexesProcessor < BaseProcessor
-      CHECKERS = [
-        Checkers::UniqueIndexChecker,
-        Checkers::RedundantIndexChecker,
-        Checkers::RedundantUniqueIndexChecker
-      ].freeze
-
       private
 
       def check # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/lib/database_consistency/processors/models_processor.rb
+++ b/lib/database_consistency/processors/models_processor.rb
@@ -4,10 +4,6 @@ module DatabaseConsistency
   module Processors
     # The class to process models
     class ModelsProcessor < BaseProcessor
-      CHECKERS = [
-        Checkers::MissingTableChecker
-      ].freeze
-
       private
 
       def check

--- a/lib/database_consistency/processors/validators_fractions_processor.rb
+++ b/lib/database_consistency/processors/validators_fractions_processor.rb
@@ -4,10 +4,6 @@ module DatabaseConsistency
   module Processors
     # The class to process validators
     class ValidatorsFractionsProcessor < BaseProcessor
-      CHECKERS = [
-        Checkers::ColumnPresenceChecker
-      ].freeze
-
       private
 
       # @return [Array<Hash>]

--- a/lib/database_consistency/processors/validators_processor.rb
+++ b/lib/database_consistency/processors/validators_processor.rb
@@ -4,11 +4,6 @@ module DatabaseConsistency
   module Processors
     # The class to process validators
     class ValidatorsProcessor < BaseProcessor
-      CHECKERS = [
-        Checkers::MissingUniqueIndexChecker,
-        Checkers::CaseSensitiveUniqueValidationChecker
-      ].freeze
-
       private
 
       # @return [Array<Hash>]

--- a/lib/database_consistency/writers/simple_writer.rb
+++ b/lib/database_consistency/writers/simple_writer.rb
@@ -5,36 +5,6 @@ module DatabaseConsistency
   module Writers
     # The simplest formatter
     class SimpleWriter < BaseWriter
-      SLUG_TO_WRITER = {
-        association_foreign_type_missing_null_constraint: Simple::AssociationForeignTypeMissingNullConstraint,
-        association_missing_index: Simple::AssociationMissingIndex,
-        association_missing_null_constraint: Simple::AssociationMissingNullConstraint,
-        enum_values_inconsistent_with_ar_enum: Simple::EnumValuesInconsistentWithArEnum,
-        enum_values_inconsistent_with_inclusion: Simple::EnumValuesInconsistentWithInclusion,
-        has_one_missing_unique_index: Simple::HasOneMissingUniqueIndex,
-        implicit_order_column_missing: Simple::ImplicitOrderColumnMissing,
-        inconsistent_enum_type: Simple::InconsistentEnumType,
-        inconsistent_types: Simple::InconsistentTypes,
-        length_validator_greater_limit: Simple::LengthValidatorGreaterLimit,
-        length_validator_lower_limit: Simple::LengthValidatorLowerLimit,
-        length_validator_missing: Simple::LengthValidatorMissing,
-        missing_association_class: Simple::MissingAssociationClass,
-        missing_foreign_key: Simple::MissingForeignKey,
-        missing_foreign_key_cascade: Simple::MissingForeignKeyCascade,
-        missing_table: Simple::MissingTable,
-        missing_unique_index: Simple::MissingUniqueIndex,
-        missing_uniqueness_validation: Simple::MissingUniquenessValidation,
-        null_constraint_association_misses_validator: Simple::NullConstraintAssociationMissesValidator,
-        null_constraint_misses_validator: Simple::NullConstraintMissesValidator,
-        null_constraint_missing: Simple::NullConstraintMissing,
-        possible_null: Simple::PossibleNull,
-        redundant_case_insensitive_option: Simple::RedundantCaseInsensitiveOption,
-        redundant_index: Simple::RedundantIndex,
-        redundant_unique_index: Simple::RedundantUniqueIndex,
-        small_primary_key: Simple::SmallPrimaryKey,
-        three_state_boolean: Simple::ThreeStateBoolean
-      }.freeze
-
       def write
         results.select(&method(:write?))
                .map(&method(:writer))
@@ -58,7 +28,12 @@ module DatabaseConsistency
       end
 
       def writer(report)
-        klass = SLUG_TO_WRITER[report.error_slug] || Simple::DefaultMessage
+        klass = begin
+                  "DatabaseConsistency::Writers::Simple::#{report.error_slug.to_s.classify}".constantize
+                rescue NameError
+                  Simple::DefaultMessage
+                end
+
         klass.new(report, config: config)
       end
     end

--- a/spec/checkers/unique_index_checker_spec.rb
+++ b/spec/checkers/unique_index_checker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DatabaseConsistency::Checkers::UniqueIndexChecker, :sqlite, :mysq
   let(:model) { klass }
   let(:index) { ActiveRecord::Base.connection.indexes(klass.table_name).first }
 
-  let(:checker_name) { described_class.to_s.split('::').last }
+  let(:checker_name) { described_class.name.demodulize }
   let(:index_name) { 'index_name' }
 
   context 'when unique index is based on association' do


### PR DESCRIPTION
Hello 👋

I want to revisit the idea we discussed in #196, as I really want to have some custom checkers in my project that are not ready to be upstreamed yet (e.g., #192).

Currently, I’m not sure how I can do that (reopening a processor class and redefining the `CHECKERS` constant maybe?). So I propose an approach that is heavily inspired by the RuboCop gem.

## What changed?
1. Processors don’t have to explicitly define the list of checkers anymore; instead, checkers will register themselves automatically upon inheritance. For example, if a checker inherits from `ColumnChecker`, it will be added to `ColumnsProcessor`; from `IndexChecker` to `IndexesProcessor`, and so on.
2. A simple writer class name is inferred automatically from the error’s slug and falls back to the `DefaultMessage` if the class is not found. This allows us to get rid of `SLUG_TO_WRITER` (something I attempted before in #149). Most importantly, we can have simple writers for our custom checkers.
3. A new configuration directive has been added: `require`. It works similarly to the one from RuboCop — you can require a checker or a whole gem (I haven’t tested the gem case).

## How does it work?
Here’s an example of integrating the checker from #192 into a dummy project:
```ruby
# Gemfile

gem 'database_consistency', group: :development, require: false
```
```yaml
# .database_consistency.yml

require:
  - ./lib/database_consistency/checkers/enum_column_checker
```
```ruby
# lib/database_consistency/checkers/enum_column_checker.rb

require_relative "../writers/simple/enum_column_type_mismatch"

module DatabaseConsistency
  module Checkers
    # This class checks that ActiveRecord enum is backed by enum column
    class EnumColumnChecker < EnumChecker
      Report = ReportBuilder.define(
        DatabaseConsistency::Report,
        :table_name,
        :column_name
      )

      private

      # ActiveRecord supports native enum type since version 7 and only for PostgreSQL
      def preconditions
        Helper.postgresql? && ActiveRecord::VERSION::MAJOR >= 7 && column.present?
      end

      def check
        if valid?
          report_template(:ok)
        else
          report_template(:fail, error_slug: :enum_column_type_mismatch)
        end
      end

      def report_template(status, error_slug: nil)
        Report.new(
          status: status,
          error_slug: error_slug,
          error_message: nil,
          table_name: model.table_name,
          column_name: column.name,
          **report_attributes
        )
      end

      def column
        @column ||= model.columns.find { |c| c.name.to_s == enum.to_s }
      end

      # @return [Boolean]
      def valid?
        column.type == :enum
      end
    end
  end
end
```
```ruby
# lib/database_consistency/writers/simple/enum_column_type_mismatch.rb

module DatabaseConsistency
  module Writers
    module Simple
      class EnumColumnTypeMismatch < Base # :nodoc:
        private

        def template
          "column should be enum type"
        end

        def unique_attributes
          {
            table_name: report.table_name,
            column_name: report.column_name
          }
        end
      end
    end
  end
end
```
```ruby
# db/migrate/20240914001835_create_things.rb

class CreateThings < ActiveRecord::Migration[7.2]
  def change
    create_table :things do |t|
      t.string :name, null: false
      t.string :status, default: 'active', null: false

      t.timestamps
    end
  end
end
```
```ruby
# app/models/thing.rb

class Thing < ApplicationRecord
  enum status: { active: "active", inactive: "inactive" }
end
```
```
$ bundle exec database_consistency 
Loaded configurations: .database_consistency.yml
NullConstraintChecker fail Thing name column is required in the database but does not have a validator disallowing nil values
EnumColumnChecker fail Thing status column should be enum type
```
That’s it; as you can see, the project-specific checker works as expected and prints our custom error message.

## Final thoughts
I would love to hear everyone’s thoughts on this. I hope I can start having custom checkers in my project soon, whether with my proposed approach or something else.

If the proposed approach is acceptable, I can work on the documentation and extend the Rails examples in the repo to demonstrate custom checkers.

Thank you.