### PR TITLE
set up migration context directly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,8 @@ jobs:
             gemfile: 'gemfiles/ar_7_0.gemfile'
           - ruby-version: '3.2'
             gemfile: 'gemfiles/ar_7_1.gemfile'
+          - ruby-version: '3.2'
+            gemfile: 'gemfiles/ar_7_2.gemfile'
           - ruby-version: 'head'
             gemfile: 'gemfiles/ar_main.gemfile'
 

--- a/Appraisals
+++ b/Appraisals
@@ -17,7 +17,7 @@ appraise 'ar_4_2' do
   gem 'sqlite3', '~> 1.3.9'
 end
 
-%w[5.2 6.0 6.1 7.0 7.1].each do |version|
+%w[5.2 6.0 6.1 7.0 7.1 7.2].each do |version|
   appraise "ar_#{version.gsub('.', '_')}" do
     remove_gem 'appraisal'
     gem 'activerecord', "~> #{version}.0"

--- a/ar_7_2.gemfile
+++ b/ar_7_2.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 7.2.0'
+gem 'mysql2', '~> 0.5'
+gem 'pg', '>= 0.2'
+gem 'sqlite3', '~> 1.3'
+
+gemspec path: '../'


### PR DESCRIPTION
it seems like the connection method `migration_context` was removed in Rails 7.2. As a result, `--autofix` raises a NoMethodError. With this change (largely borrowed from the Combustion gem), it should be possible to create a MigrationContext on Rails 6 and 7, even if the connection object doesn't provide one directly. At least, these changes work for me on Rails 7.2.