### PR TITLE
Fix enum value checker to handle multiple rails versions

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -20,6 +20,7 @@ end
 %w[5.2 6.0 6.1 7.0 7.1].each do |version|
   appraise "ar_#{version.gsub('.', '_')}" do
     remove_gem 'appraisal'
+    gem 'concurrent-ruby', '1.3.4'
     gem 'activerecord', "~> #{version}.0"
     gem 'sqlite3', '~> 1.3'
   end

--- a/lib/database_consistency/checkers/column_checkers/enum_value_checker.rb
+++ b/lib/database_consistency/checkers/column_checkers/enum_value_checker.rb
@@ -38,7 +38,11 @@ module DatabaseConsistency
         @enum_column_values ||=
           if model.connection.enum_types.is_a?(Array)
             _, values = model.connection.enum_types.find { |(enum, _)| enum == column.sql_type }
-            values.split(',').map(&:strip)
+            case values
+            when Array then values
+            else
+              values.split(',').map(&:strip)
+            end
           else
             # active_record-postgres_enum gem
             model.connection.enum_types[column.sql_type.to_sym]

--- a/rails6-example/Gemfile
+++ b/rails6-example/Gemfile
@@ -3,6 +3,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'database_consistency', path: '../', group: :development, require: false
 
+# https://github.com/rails/rails/pull/54264
+gem 'concurrent-ruby', '1.3.4'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.0'
 # Use sqlite3 as the database for Active Record

--- a/rails7-example/Gemfile
+++ b/rails7-example/Gemfile
@@ -5,6 +5,11 @@ gem 'database_consistency', path: '../', group: :development, require: false
 
 gem "pg"
 
+gem "logger"
+
+# https://github.com/rails/rails/pull/54264
+gem 'concurrent-ruby', '1.3.4'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.6"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+require 'logger'
 require 'database_consistency'
 require 'database_context'
 


### PR DESCRIPTION
Following the change in how enums are retrieved ( using `array_agg` instead of `string_agg` ) in https://github.com/rails/rails/pull/54141

This commit makes this gem foreward/backward compatible with Rails.