### PR TITLE
Fix use of .then to support Ruby < 2.6

### DIFF
--- a/lib/database_consistency/configuration.rb
+++ b/lib/database_consistency/configuration.rb
@@ -8,14 +8,15 @@ module DatabaseConsistency
     DEFAULT_PATH = '.database_consistency.yml'
 
     def initialize(file_paths = DEFAULT_PATH)
-      @configuration = existing_configurations(file_paths).then do |existing_paths|
-        if existing_paths.any?
-          puts "Loaded configurations: #{existing_paths.join(', ')}"
-        else
-          puts 'No configurations were provided'
-        end
-        extract_configurations(existing_paths)
+      existing_paths = existing_configurations(file_paths)
+
+      if existing_paths.any?
+        puts "Loaded configurations: #{existing_paths.join(', ')}"
+      else
+        puts 'No configurations were provided'
       end
+
+      @configuration = extract_configurations(existing_paths)
 
       load_custom_checkers
     end


### PR DESCRIPTION
This PR replaces the use of `.then` with standard control flow to maintain compatibility with older Ruby versions (e.g., 2.5.6). This ensures the gem works in environments still using Ruby 2.5 without raising `NoMethodError`.

Fixes: #253 