### PR TITLE
Support more cases for ForeignKeyChecker

### DIFF
--- a/lib/database_consistency/checkers/association_checkers/foreign_key_checker.rb
+++ b/lib/database_consistency/checkers/association_checkers/foreign_key_checker.rb
@@ -43,7 +43,14 @@ module DatabaseConsistency
       # | persisted   | ok     |
       # | missing     | fail   |
       def check
-        if model.connection.foreign_keys(model.table_name).find { |fk| fk.column == association.foreign_key.to_s }
+        fk = model.connection.foreign_keys(model.table_name).find do |fk|
+          next false unless fk.column.include?(association.foreign_key.to_s)
+          next false unless fk.to_table == association.klass.table_name
+
+          true
+        end
+
+        if fk
           report_template(:ok)
         else
           report_template(:fail, error_slug: :missing_foreign_key)


### PR DESCRIPTION
I came across 2 edge-cases which weren't supported by this checker:
- if a table has 2 associations defined on the same foreign_key pointing to 2 different tables, any database foreign key on this column would make the check pass for both associations.
- if the database foreign key is a multicolumn one (typically `child(tenant_id, parent_id)` referencing `parent(tenant_id, id)` in a tenanted scenario), this foreign key should be accepted for the `Child.belongs_to :parent` association