### PR TITLE
Fix MissingDependentDestroyChecker when classes are namespaced

### DIFF
--- a/lib/database_consistency/checkers/association_checkers/missing_dependent_destroy_checker.rb
+++ b/lib/database_consistency/checkers/association_checkers/missing_dependent_destroy_checker.rb
@@ -27,7 +27,7 @@ module DatabaseConsistency
       end
 
       def dependent_destroy_exists?
-        association.class_name.constantize.reflect_on_all_associations.any? do |association|
+        association.klass.reflect_on_all_associations.any? do |association|
           %i[has_many has_one].include?(association.macro) &&
             DEPENDENT_OPTIONS.include?(association.options[:dependent]) &&
             association.table_name == model.table_name


### PR DESCRIPTION
Currently, the following is raising a `NameError` because the association class name isn't `User` but `Blog::User`:
```
module Blog
  class User
    has_many :posts
  end
end

module Blog
  class Post
    belongs_to :user 
  end
end