### PR TITLE
Fix grammar, spelling, and terminology in messages

### DIFF
--- a/lib/database_consistency/configuration.rb
+++ b/lib/database_consistency/configuration.rb
@@ -13,7 +13,7 @@ module DatabaseConsistency
       if existing_paths.any?
         puts "Loaded configurations: #{existing_paths.join(', ')}"
       else
-        puts 'No configurations were provided'
+        puts 'No configuration files were provided'
       end
 
       @configuration = extract_configurations(existing_paths)

--- a/lib/database_consistency/helper.rb
+++ b/lib/database_consistency/helper.rb
@@ -49,7 +49,7 @@ module DatabaseConsistency
     def connected?(klass)
       klass.connection
     rescue ActiveRecord::ConnectionNotEstablished
-      puts "#{klass} doesn't have active connection: ignoring"
+      puts "#{klass} does not have an active connection, skipping"
       false
     end
 

--- a/lib/database_consistency/rescue_error.rb
+++ b/lib/database_consistency/rescue_error.rb
@@ -16,9 +16,9 @@ module DatabaseConsistency
     end
 
     def initialize
-      puts 'Hey, some checks fail with an error, please open an issue on github at https://github.com/djezzzl/database_consistency.'
-      puts "Attach the created file: #{filename}"
-      puts 'Thank you, for your contribution!'
+      puts 'Some checks failed with an error. Please open an issue on GitHub at https://github.com/djezzzl/database_consistency.'
+      puts "Attach the generated file: #{filename}"
+      puts 'Thank you for your contribution!'
       puts '(c) Evgeniy Demin <lawliet.djez@gmail.com>'
     end
 

--- a/lib/database_consistency/writers/autofix/migration_base.rb
+++ b/lib/database_consistency/writers/autofix/migration_base.rb
@@ -10,7 +10,7 @@ module DatabaseConsistency
           file_path = migration_path(migration_name)
 
           if Dir[migration_path_pattern(migration_name)].any?
-            p "Skipping migration #{migration_name} because it already exists"
+            puts "Skipping migration #{migration_name} because it already exists"
           else
             File.write(file_path, migration)
           end

--- a/lib/database_consistency/writers/simple/association_foreign_type_missing_null_constraint.rb
+++ b/lib/database_consistency/writers/simple/association_foreign_type_missing_null_constraint.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'association foreign type column should be required in the database'
+          'association foreign type column should be NOT NULL'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/association_missing_index.rb
+++ b/lib/database_consistency/writers/simple/association_missing_index.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'associated model should have proper index in the database'
+          'associated model should have an index in the database'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/association_missing_null_constraint.rb
+++ b/lib/database_consistency/writers/simple/association_missing_null_constraint.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'association foreign key column should be required in the database'
+          'association foreign key column should be NOT NULL'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/enum_values_inconsistent_with_ar_enum.rb
+++ b/lib/database_consistency/writers/simple/enum_values_inconsistent_with_ar_enum.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'enum has [%<enum_values>s] values but ActiveRecord enum has [%<declared_values>s] values'
+          'database enum has values [%<enum_values>s] but ActiveRecord enum has values [%<declared_values>s]'
         end
 
         def attributes

--- a/lib/database_consistency/writers/simple/enum_values_inconsistent_with_inclusion.rb
+++ b/lib/database_consistency/writers/simple/enum_values_inconsistent_with_inclusion.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'enum has [%<enum_values>s] values but ActiveRecord inclusion validation has [%<declared_values>s] values'
+          'database enum has values [%<enum_values>s] but inclusion validation has values [%<declared_values>s]'
         end
 
         def attributes

--- a/lib/database_consistency/writers/simple/has_one_missing_unique_index.rb
+++ b/lib/database_consistency/writers/simple/has_one_missing_unique_index.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'associated model should have proper unique index in the database'
+          'associated model should have a unique index in the database'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/implicit_order_column_missing.rb
+++ b/lib/database_consistency/writers/simple/implicit_order_column_missing.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'implicit_order_column is recommended when using uuid column type for primary key'
+          'setting implicit_order_column is recommended when using UUID as the primary key type'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/inconsistent_enum_type.rb
+++ b/lib/database_consistency/writers/simple/inconsistent_enum_type.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'enum has %<values_types>s types but column has %<column_type>s type'
+          'enum values have %<values_types>s types but the column has %<column_type>s type'
         end
 
         def attributes

--- a/lib/database_consistency/writers/simple/inconsistent_types.rb
+++ b/lib/database_consistency/writers/simple/inconsistent_types.rb
@@ -7,8 +7,8 @@ module DatabaseConsistency
         private
 
         def template
-          "foreign key (%<fk_name>s) with type (%<fk_type>s) doesn't "\
-          'cover primary key (%<pk_name>s) with type (%<pk_type>s)'
+          'foreign key (%<fk_name>s) with type (%<fk_type>s) does not match '\
+          'primary key (%<pk_name>s) with type (%<pk_type>s)'
         end
 
         def attributes

--- a/lib/database_consistency/writers/simple/length_validator_greater_limit.rb
+++ b/lib/database_consistency/writers/simple/length_validator_greater_limit.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'column has greater limit in the database than in length validator'
+          'column character limit is greater than the length validator allows'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/length_validator_lower_limit.rb
+++ b/lib/database_consistency/writers/simple/length_validator_lower_limit.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'column has lower limit in the database than in length validator'
+          'column character limit is less than the length validator allows'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/length_validator_missing.rb
+++ b/lib/database_consistency/writers/simple/length_validator_missing.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'column has limit in the database but do not have length validator'
+          'column has a character length limit but does not have a length validator'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/missing_association_class.rb
+++ b/lib/database_consistency/writers/simple/missing_association_class.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'refers to undefined model %<class_name>s'
+          'refers to a non-existent model %<class_name>s'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/missing_foreign_key.rb
+++ b/lib/database_consistency/writers/simple/missing_foreign_key.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'should have foreign key in the database'
+          'should have a foreign key in the database'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/missing_foreign_key_cascade.rb
+++ b/lib/database_consistency/writers/simple/missing_foreign_key_cascade.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'should have foreign key with on_delete: :%<cascade_option>s in the database'
+          'should have a foreign key with on_delete: :%<cascade_option>s in the database'
         end
 
         def attributes

--- a/lib/database_consistency/writers/simple/missing_index_find_by.rb
+++ b/lib/database_consistency/writers/simple/missing_index_find_by.rb
@@ -13,7 +13,7 @@ module DatabaseConsistency
         def attributes
           if report.source_location
             count = report.total_findings_count || 1
-            count_str = count > 1 ? ", and #{count - 1} more occurrences" : ''
+            count_str = count > 1 ? ", and #{count - 1} more" : ''
             { source_location: " (found at #{report.source_location}#{count_str})" }
           else
             { source_location: '' }

--- a/lib/database_consistency/writers/simple/missing_table.rb
+++ b/lib/database_consistency/writers/simple/missing_table.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'should have a table in the database'
+          'should have a corresponding table in the database'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/missing_unique_index.rb
+++ b/lib/database_consistency/writers/simple/missing_unique_index.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'model should have proper unique index in the database'
+          'model should have a unique index in the database'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/missing_uniqueness_validation.rb
+++ b/lib/database_consistency/writers/simple/missing_uniqueness_validation.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'index is unique in the database but do not have uniqueness validator'
+          'index is unique in the database but does not have a uniqueness validator'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/null_constraint_association_misses_validator.rb
+++ b/lib/database_consistency/writers/simple/null_constraint_association_misses_validator.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'column is required in the database but do not have presence validator for association %<association_name>s'
+          'column is NOT NULL but does not have a presence validator for association %<association_name>s'
         end
 
         def attributes

--- a/lib/database_consistency/writers/simple/null_constraint_misses_validator.rb
+++ b/lib/database_consistency/writers/simple/null_constraint_misses_validator.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'column is required in the database but does not have a validator disallowing nil values'
+          'column is NOT NULL but does not have a validator disallowing nil values'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/null_constraint_missing.rb
+++ b/lib/database_consistency/writers/simple/null_constraint_missing.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'column should be required in the database'
+          'column should be NOT NULL'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/possible_null.rb
+++ b/lib/database_consistency/writers/simple/possible_null.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'column is required but there is possible null value insert'
+          'column is NOT NULL but may receive a NULL value'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/redundant_case_insensitive_option.rb
+++ b/lib/database_consistency/writers/simple/redundant_case_insensitive_option.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          "has case insensitive type and doesn't require case_sensitive: false option"
+          'column has a case-insensitive type and does not need the case_sensitive: false option'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/redundant_index.rb
+++ b/lib/database_consistency/writers/simple/redundant_index.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'index is redundant as %<covered_index_name>s covers it'
+          'index is redundant because %<covered_index_name>s covers it'
         end
 
         def attributes

--- a/lib/database_consistency/writers/simple/redundant_unique_index.rb
+++ b/lib/database_consistency/writers/simple/redundant_unique_index.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'index uniqueness is redundant as %<covered_index_name>s covers it'
+          'index uniqueness is redundant because %<covered_index_name>s covers it'
         end
 
         def attributes

--- a/lib/database_consistency/writers/simple/small_primary_key.rb
+++ b/lib/database_consistency/writers/simple/small_primary_key.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'column has int/serial type but recommended to have bigint/bigserial/uuid'
+          'column has int/serial type but it is recommended to use bigint/bigserial/uuid'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/three_state_boolean.rb
+++ b/lib/database_consistency/writers/simple/three_state_boolean.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'boolean column should have NOT NULL constraint'
+          'boolean column should be NOT NULL'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/view_missing_primary_key.rb
+++ b/lib/database_consistency/writers/simple/view_missing_primary_key.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'model pointing to a view should have primary_key set'
+          'model backed by a database view should have primary_key set'
         end
 
         def unique_attributes

--- a/lib/database_consistency/writers/simple/view_primary_key_column_missing.rb
+++ b/lib/database_consistency/writers/simple/view_primary_key_column_missing.rb
@@ -7,7 +7,7 @@ module DatabaseConsistency
         private
 
         def template
-          'model pointing to a view has a non-existent primary_key column set'
+          'model backed by a database view has primary_key set to a non-existent column'
         end
 
         def unique_attributes


### PR DESCRIPTION
The messages these checks output are an important signal, so they deserve a bit of TLC. Some changes are just grammar, but a few are more important. For example, there is no such thing as a "required database column" - there is such thing as a `NOT NULL`, so this is what the message should state.

- Replace "required"/"required in the database" with "NOT NULL" (correct database terminology instead of a misnomer)
- Fix subject-verb agreement ("do not have" → "does not have")
- Add missing articles ("a", "an", "the")
- Use US spelling and proper capitalization ("github" → "GitHub", "uuid" → "UUID")
- Improve clarity of length validator messages to mention character limits
- Use "does not" instead of contractions for consistency
- Replace vague "proper index" with "an index"/"a unique index"
- Fix comma splice ("Thank you, for" → "Thank you for")
- Use puts instead of p for user-facing output in migration_base