### PR TITLE
feat(autofix): scope --autofix via --only-checkers=LIST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- Add `--only-checkers=LIST` to scope `--autofix` to offenses produced by specific checker class names (comma-separated, e.g. `--only-checkers=ColumnPresenceChecker,NullConstraintChecker`). Unknown names are rejected before any checks run.
 - Special thanks to [Chedli Bourguiba](https://github.com/chaadow) for improving conditional index matching in [#298](https://github.com/djezzzl/database_consistency/pull/298)!
 
 ### [3.0.2] - 2026/03/21

--- a/bin/database_consistency
+++ b/bin/database_consistency
@@ -39,8 +39,10 @@ opt_parser = OptionParser.new do |opts|
     options[:todo] = true
   end
 
-  opts.on('-f', '--autofix', 'Automatically fixes issues by adjusting the code or generating missing migrations.') do
-    options[:autofix] = true
+  opts.on('-f', '--autofix [CHECKER,CHECKER,...]', Array,
+          'Automatically fixes issues by adjusting the code or generating missing migrations. ' \
+          'Optionally accepts a comma-separated list of checker class names to scope the fix (e.g. ColumnPresenceChecker).') do |checkers|
+    options[:autofix] = checkers || true
   end
 
   opts.on('-h', '--help', 'Prints this help.') do
@@ -75,5 +77,10 @@ $LOAD_PATH.unshift(File.expand_path('lib', __dir__))
 require 'database_consistency'
 
 # Process checks
-code = DatabaseConsistency.run(config, **options)
+begin
+  code = DatabaseConsistency.run(config, **options)
+rescue DatabaseConsistency::Writers::AutofixWriter::UnknownCheckerError => e
+  warn e.message
+  exit 1
+end
 exit code

--- a/bin/database_consistency
+++ b/bin/database_consistency
@@ -39,10 +39,15 @@ opt_parser = OptionParser.new do |opts|
     options[:todo] = true
   end
 
-  opts.on('-f', '--autofix [CHECKER,CHECKER,...]', Array,
-          'Automatically fixes issues by adjusting the code or generating missing migrations. ' \
-          'Optionally accepts a comma-separated list of checker class names to scope the fix (e.g. ColumnPresenceChecker).') do |checkers|
-    options[:autofix] = checkers || true
+  opts.on('-f', '--autofix',
+          'Automatically fixes issues by adjusting the code or generating missing migrations.') do
+    options[:autofix] = true
+  end
+
+  opts.on('--only-checkers=LIST', Array,
+          'When used with --autofix, restricts the fix to offenses produced by the listed checker ' \
+          'class names (comma-separated, e.g. ColumnPresenceChecker,NullConstraintChecker).') do |checkers|
+    options[:only_checkers] = checkers
   end
 
   opts.on('-h', '--help', 'Prints this help.') do
@@ -52,6 +57,11 @@ opt_parser = OptionParser.new do |opts|
 end
 
 opt_parser.parse!
+
+if options[:only_checkers] && !options[:autofix]
+  warn '--only-checkers requires --autofix'
+  exit 1
+end
 
 base_dir = File.join(Dir.pwd, ARGV.first.to_s)
 unless File.realpath(base_dir).start_with?(Dir.pwd)

--- a/docs/wiki/auto-correction.md
+++ b/docs/wiki/auto-correction.md
@@ -3,3 +3,17 @@ The tool has an auto-correction option supported. You can run it with the follow
 ```bash
 $ bundle exec database_consistency -f
 ```
+
+## Scoping auto-correction to specific checkers
+
+`-f` optionally accepts a comma-separated list of checker class names. Only offenses produced by the listed checkers are auto-corrected; other offenses are left untouched.
+
+```bash
+# Fix only ColumnPresenceChecker offenses:
+$ bundle exec database_consistency -f ColumnPresenceChecker
+
+# Fix ColumnPresenceChecker and NullConstraintChecker offenses:
+$ bundle exec database_consistency -f ColumnPresenceChecker,NullConstraintChecker
+```
+
+Unknown checker names are rejected with a non-zero exit code and a list of the valid names.

--- a/docs/wiki/auto-correction.md
+++ b/docs/wiki/auto-correction.md
@@ -6,14 +6,14 @@ $ bundle exec database_consistency -f
 
 ## Scoping auto-correction to specific checkers
 
-`-f` optionally accepts a comma-separated list of checker class names. Only offenses produced by the listed checkers are auto-corrected; other offenses are left untouched.
+Pair `--autofix` with `--only-checkers=LIST` to restrict auto-correction to a comma-separated list of checker class names. Offenses from every other checker are left untouched.
 
 ```bash
 # Fix only ColumnPresenceChecker offenses:
-$ bundle exec database_consistency -f ColumnPresenceChecker
+$ bundle exec database_consistency --autofix --only-checkers=ColumnPresenceChecker
 
 # Fix ColumnPresenceChecker and NullConstraintChecker offenses:
-$ bundle exec database_consistency -f ColumnPresenceChecker,NullConstraintChecker
+$ bundle exec database_consistency -f --only-checkers=ColumnPresenceChecker,NullConstraintChecker
 ```
 
-Unknown checker names are rejected with a non-zero exit code and a list of the valid names.
+Names must match the checker class name exactly (e.g. `ColumnPresenceChecker`, not `column_presence_checker`). Unknown names are rejected before any checks run, with a non-zero exit code and a list of the valid names. `--only-checkers` on its own (without `--autofix`) also exits with an error.

--- a/lib/database_consistency.rb
+++ b/lib/database_consistency.rb
@@ -121,7 +121,7 @@ module DatabaseConsistency
       reports = Processors.reports(configuration)
 
       if opts[:autofix]
-        Writers::AutofixWriter.write(reports, config: configuration)
+        Writers::AutofixWriter.write(reports, config: configuration, opts: opts[:autofix])
 
         0
       elsif opts[:todo]

--- a/lib/database_consistency.rb
+++ b/lib/database_consistency.rb
@@ -116,12 +116,15 @@ require 'database_consistency/checkers/index_checkers/redundant_unique_index_che
 # The root module
 module DatabaseConsistency
   class << self
-    def run(*args, **opts) # rubocop:disable Metrics/MethodLength
+    def run(*args, **opts) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       configuration = Configuration.new(*args)
+
+      Writers::AutofixWriter.validate_scope!(opts[:only_checkers]) if opts[:autofix]
+
       reports = Processors.reports(configuration)
 
       if opts[:autofix]
-        Writers::AutofixWriter.write(reports, config: configuration, opts: opts[:autofix])
+        Writers::AutofixWriter.write(reports, config: configuration, opts: opts[:only_checkers])
 
         0
       elsif opts[:todo]

--- a/lib/database_consistency/writers/autofix_writer.rb
+++ b/lib/database_consistency/writers/autofix_writer.rb
@@ -5,6 +5,8 @@ module DatabaseConsistency
   module Writers
     # The simplest formatter
     class AutofixWriter < BaseWriter
+      UnknownCheckerError = Class.new(StandardError)
+
       SLUG_TO_GENERATOR = {
         association_missing_index: Autofix::AssociationMissingIndex,
         association_missing_null_constraint: Autofix::NullConstraintMissing,
@@ -21,10 +23,22 @@ module DatabaseConsistency
       }.freeze
 
       def write
+        validate_scope!
         unique_generators.each(&:fix!)
       end
 
       private
+
+      def validate_scope!
+        return unless opts.is_a?(Array)
+
+        known = Checkers::BaseChecker.descendants.map(&:checker_name)
+        unknown = opts - known
+        return if unknown.empty?
+
+        raise UnknownCheckerError,
+              "unknown checker(s): #{unknown.join(', ')}. Known: #{known.sort.uniq.join(', ')}"
+      end
 
       def unique_generators
         results
@@ -35,7 +49,13 @@ module DatabaseConsistency
       end
 
       def fix?(report)
-        report.status == :fail
+        report.status == :fail && scoped?(report)
+      end
+
+      def scoped?(report)
+        return true unless opts.is_a?(Array)
+
+        opts.include?(report.checker_name)
       end
 
       def generator(report)

--- a/lib/database_consistency/writers/autofix_writer.rb
+++ b/lib/database_consistency/writers/autofix_writer.rb
@@ -22,23 +22,34 @@ module DatabaseConsistency
         three_state_boolean: Autofix::NullConstraintMissing
       }.freeze
 
+      class << self
+        def validate_scope!(scope)
+          return if scope.nil?
+
+          known = concrete_checker_names
+          unknown = scope - known
+          return if unknown.empty?
+
+          raise UnknownCheckerError,
+                "unknown checker(s): #{unknown.join(', ')}. Known: #{known.join(', ')}"
+        end
+
+        private
+
+        def concrete_checker_names
+          Checkers::BaseChecker.descendants
+                               .reject { |checker| checker.superclass == Checkers::BaseChecker }
+                               .map(&:checker_name)
+                               .uniq
+                               .sort
+        end
+      end
+
       def write
-        validate_scope!
         unique_generators.each(&:fix!)
       end
 
       private
-
-      def validate_scope!
-        return unless opts.is_a?(Array)
-
-        known = Checkers::BaseChecker.descendants.map(&:checker_name)
-        unknown = opts - known
-        return if unknown.empty?
-
-        raise UnknownCheckerError,
-              "unknown checker(s): #{unknown.join(', ')}. Known: #{known.sort.uniq.join(', ')}"
-      end
 
       def unique_generators
         results
@@ -53,7 +64,7 @@ module DatabaseConsistency
       end
 
       def scoped?(report)
-        return true unless opts.is_a?(Array)
+        return true if opts.nil?
 
         opts.include?(report.checker_name)
       end

--- a/lib/database_consistency/writers/base_writer.rb
+++ b/lib/database_consistency/writers/base_writer.rb
@@ -4,15 +4,16 @@ module DatabaseConsistency
   module Writers
     # The base class for writers
     class BaseWriter
-      attr_reader :results, :config
+      attr_reader :results, :config, :opts
 
-      def initialize(results, config: Configuration.new)
+      def initialize(results, config: Configuration.new, opts: nil)
         @results = results
         @config = config
+        @opts = opts
       end
 
-      def self.write(results, config: Configuration.new)
-        new(results, config: config).write
+      def self.write(results, config: Configuration.new, opts: nil)
+        new(results, config: config, opts: opts).write
       end
     end
   end

--- a/spec/writers/autofix_writer_spec.rb
+++ b/spec/writers/autofix_writer_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe DatabaseConsistency::Writers::AutofixWriter, :sqlite, :mysql, :postgresql do
   let(:config) { DatabaseConsistency::Configuration.new }
 
-  def build_report(status:, error_slug:)
-    double('report', status: status, error_slug: error_slug)
+  def build_report(status:, error_slug:, checker_name: 'NullConstraintChecker')
+    double('report', status: status, error_slug: error_slug, checker_name: checker_name)
   end
 
   describe '#write' do
@@ -71,7 +71,9 @@ RSpec.describe DatabaseConsistency::Writers::AutofixWriter, :sqlite, :mysql, :po
 
     context 'when there are different generators' do
       let(:null_report) { build_report(status: :fail, error_slug: :null_constraint_missing) }
-      let(:index_report) { build_report(status: :fail, error_slug: :redundant_index) }
+      let(:index_report) do
+        build_report(status: :fail, error_slug: :redundant_index, checker_name: 'RedundantIndexChecker')
+      end
       let(:reports) { [null_report, index_report] }
 
       before do
@@ -85,6 +87,110 @@ RSpec.describe DatabaseConsistency::Writers::AutofixWriter, :sqlite, :mysql, :po
         expect_any_instance_of(DatabaseConsistency::Writers::Autofix::NullConstraintMissing)
           .to receive(:fix!).once
         expect_any_instance_of(DatabaseConsistency::Writers::Autofix::RedundantIndex)
+          .to receive(:fix!).once
+        write
+      end
+    end
+
+    context 'when opts restricts to a single checker name' do
+      subject(:write) { described_class.write(reports, config: config, opts: ['NullConstraintChecker']) }
+
+      let(:null_report) do
+        build_report(status: :fail, error_slug: :null_constraint_missing, checker_name: 'NullConstraintChecker')
+      end
+      let(:index_report) do
+        build_report(status: :fail, error_slug: :redundant_index, checker_name: 'RedundantIndexChecker')
+      end
+      let(:reports) { [null_report, index_report] }
+
+      before do
+        allow(null_report).to receive(:table_name).and_return('users')
+        allow(null_report).to receive(:column_name).and_return('email')
+        allow(index_report).to receive(:index_name).and_return('index_users_on_email')
+        allow(index_report).to receive(:table_name).and_return('users')
+      end
+
+      it 'calls fix! only on the scoped checker generator' do
+        expect_any_instance_of(DatabaseConsistency::Writers::Autofix::NullConstraintMissing)
+          .to receive(:fix!).once
+        expect_any_instance_of(DatabaseConsistency::Writers::Autofix::RedundantIndex)
+          .not_to receive(:fix!)
+        write
+      end
+    end
+
+    context 'when opts lists several known checker names' do
+      subject(:write) do
+        described_class.write(reports, config: config, opts: %w[NullConstraintChecker RedundantIndexChecker])
+      end
+
+      let(:null_report) do
+        build_report(status: :fail, error_slug: :null_constraint_missing, checker_name: 'NullConstraintChecker')
+      end
+      let(:index_report) do
+        build_report(status: :fail, error_slug: :redundant_index, checker_name: 'RedundantIndexChecker')
+      end
+      let(:reports) { [null_report, index_report] }
+
+      before do
+        allow(null_report).to receive(:table_name).and_return('users')
+        allow(null_report).to receive(:column_name).and_return('email')
+        allow(index_report).to receive(:index_name).and_return('index_users_on_email')
+        allow(index_report).to receive(:table_name).and_return('users')
+      end
+
+      it 'calls fix! on each scoped generator' do
+        expect_any_instance_of(DatabaseConsistency::Writers::Autofix::NullConstraintMissing)
+          .to receive(:fix!).once
+        expect_any_instance_of(DatabaseConsistency::Writers::Autofix::RedundantIndex)
+          .to receive(:fix!).once
+        write
+      end
+    end
+
+    context 'when opts contains an unknown checker name' do
+      subject(:write) { described_class.write(reports, config: config, opts: ['DoesNotExist']) }
+
+      let(:reports) { [build_report(status: :fail, error_slug: :null_constraint_missing)] }
+
+      it 'raises UnknownCheckerError listing the unknown name' do
+        expect { write }.to raise_error(
+          DatabaseConsistency::Writers::AutofixWriter::UnknownCheckerError,
+          /DoesNotExist/
+        )
+      end
+    end
+
+    context 'when opts mixes known and unknown names' do
+      subject(:write) do
+        described_class.write(reports, config: config, opts: %w[NullConstraintChecker DoesNotExist])
+      end
+
+      let(:reports) { [build_report(status: :fail, error_slug: :null_constraint_missing)] }
+
+      it 'raises UnknownCheckerError without fixing anything' do
+        expect_any_instance_of(DatabaseConsistency::Writers::Autofix::NullConstraintMissing)
+          .not_to receive(:fix!)
+        expect { write }.to raise_error(
+          DatabaseConsistency::Writers::AutofixWriter::UnknownCheckerError,
+          /DoesNotExist/
+        )
+      end
+    end
+
+    context 'when opts is true (flag without arg)' do
+      subject(:write) { described_class.write(reports, config: config, opts: true) }
+
+      let(:report) { build_report(status: :fail, error_slug: :null_constraint_missing) }
+      let(:reports) { [report] }
+
+      before do
+        allow(report).to receive(:table_name).and_return('users')
+        allow(report).to receive(:column_name).and_return('email')
+      end
+
+      it 'fixes everything like the unscoped flag' do
+        expect_any_instance_of(DatabaseConsistency::Writers::Autofix::NullConstraintMissing)
           .to receive(:fix!).once
         write
       end

--- a/spec/writers/autofix_writer_spec.rb
+++ b/spec/writers/autofix_writer_spec.rb
@@ -147,52 +147,59 @@ RSpec.describe DatabaseConsistency::Writers::AutofixWriter, :sqlite, :mysql, :po
         write
       end
     end
+  end
 
-    context 'when opts contains an unknown checker name' do
-      subject(:write) { described_class.write(reports, config: config, opts: ['DoesNotExist']) }
+  describe '.validate_scope!' do
+    subject(:validate) { described_class.validate_scope!(scope) }
 
-      let(:reports) { [build_report(status: :fail, error_slug: :null_constraint_missing)] }
+    context 'when scope is nil' do
+      let(:scope) { nil }
+
+      it { expect { validate }.not_to raise_error }
+    end
+
+    context 'when scope is empty' do
+      let(:scope) { [] }
+
+      it { expect { validate }.not_to raise_error }
+    end
+
+    context 'when every name is a concrete checker' do
+      let(:scope) { %w[NullConstraintChecker RedundantIndexChecker ColumnPresenceChecker] }
+
+      it { expect { validate }.not_to raise_error }
+    end
+
+    context 'when a name is unknown' do
+      let(:scope) { ['DoesNotExist'] }
 
       it 'raises UnknownCheckerError listing the unknown name' do
-        expect { write }.to raise_error(
+        expect { validate }.to raise_error(
           DatabaseConsistency::Writers::AutofixWriter::UnknownCheckerError,
           /DoesNotExist/
         )
       end
     end
 
-    context 'when opts mixes known and unknown names' do
-      subject(:write) do
-        described_class.write(reports, config: config, opts: %w[NullConstraintChecker DoesNotExist])
-      end
+    context 'when scope mixes known and unknown names' do
+      let(:scope) { %w[NullConstraintChecker DoesNotExist] }
 
-      let(:reports) { [build_report(status: :fail, error_slug: :null_constraint_missing)] }
-
-      it 'raises UnknownCheckerError without fixing anything' do
-        expect_any_instance_of(DatabaseConsistency::Writers::Autofix::NullConstraintMissing)
-          .not_to receive(:fix!)
-        expect { write }.to raise_error(
+      it 'raises UnknownCheckerError regardless of the known ones' do
+        expect { validate }.to raise_error(
           DatabaseConsistency::Writers::AutofixWriter::UnknownCheckerError,
           /DoesNotExist/
         )
       end
     end
 
-    context 'when opts is true (flag without arg)' do
-      subject(:write) { described_class.write(reports, config: config, opts: true) }
+    context 'when scope references an abstract parent class' do
+      let(:scope) { ['ColumnChecker'] }
 
-      let(:report) { build_report(status: :fail, error_slug: :null_constraint_missing) }
-      let(:reports) { [report] }
-
-      before do
-        allow(report).to receive(:table_name).and_return('users')
-        allow(report).to receive(:column_name).and_return('email')
-      end
-
-      it 'fixes everything like the unscoped flag' do
-        expect_any_instance_of(DatabaseConsistency::Writers::Autofix::NullConstraintMissing)
-          .to receive(:fix!).once
-        write
+      it 'rejects abstract parents' do
+        expect { validate }.to raise_error(
+          DatabaseConsistency::Writers::AutofixWriter::UnknownCheckerError,
+          /ColumnChecker/
+        )
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds `--only-checkers=LIST` to scope `--autofix` to a comma-separated list of checker class names. Offenses from every other checker are left untouched.

```bash
# Fix only ColumnPresenceChecker offenses:
bundle exec database_consistency --autofix --only-checkers=ColumnPresenceChecker

# Fix ColumnPresenceChecker and NullConstraintChecker offenses:
bundle exec database_consistency -f --only-checkers=ColumnPresenceChecker,NullConstraintChecker
```

## Why

Today the only way to restrict `-f` to a single offense type is a dedicated YAML config that disables every other checker — a throwaway file that clutters the repo. `--only-checkers` is a one-shot flag that expresses intent inline and is easy to drop into `just` recipes, CI steps, or ad-hoc runs.

## Behavior

- `--autofix` alone — unchanged (fixes every offense).
- `--autofix --only-checkers=X,Y` — fixes only offenses whose `checker_name` matches `X` or `Y`.
- Unknown checker names are rejected **before** any checks run, with a non-zero exit code and the list of valid names.
- `--only-checkers` without `--autofix` also exits with an error.
- Validation filters out abstract parent classes (e.g. `ColumnChecker`, `IndexChecker`) so only concrete checkers are accepted, matching the convention in `BaseChecker.inherited`.

## Changes

- `bin/database_consistency` — add `--only-checkers=LIST`, keep `-f` boolean.
- `lib/database_consistency.rb` — call `AutofixWriter.validate_scope!` before `Processors.reports` so bad names fail fast.
- `lib/database_consistency/writers/base_writer.rb` — thread `opts:` through writers.
- `lib/database_consistency/writers/autofix_writer.rb` — `UnknownCheckerError`, `validate_scope!`, concrete-checker filter, per-report `scoped?` filter.
- `docs/wiki/auto-correction.md` — usage section.
- `CHANGELOG.md` — entry under `### Unreleased`.
- `spec/writers/autofix_writer_spec.rb` — coverage for scoped writes, `validate_scope!` (nil / empty / all-known / unknown / mixed / abstract-parent).

## Test plan

- [x] `bundle exec rspec` — 257 examples, 0 failures (sqlite).
- [x] `bundle exec rubocop` — clean (default scope).
- [x] CI matrix (mysql / postgresql / all AR versions) — waiting on CI.
- [x] Manual smoke test on a Rails app: `-f --only-checkers=ColumnPresenceChecker` only adjusts presence offenses; `-f --only-checkers=DoesNotExist` exits 1 with the known-names list.

## Semver

New public CLI flag, backward-compatible. Suggest bumping to `3.1.0` in the release commit.