### PR TITLE
Fix false negative in RedundantUniqueIndexChecker

### DIFF
--- a/lib/database_consistency/checkers/index_checkers/redundant_unique_index_checker.rb
+++ b/lib/database_consistency/checkers/index_checkers/redundant_unique_index_checker.rb
@@ -60,7 +60,7 @@ module DatabaseConsistency
 
       def contain_index?(another_index)
         another_index_columns = Helper.extract_index_columns(another_index.columns)
-        index_columns & another_index_columns == another_index_columns
+        (another_index_columns - index_columns).empty?
       end
 
       def index_columns

--- a/spec/checkers/redundant_unique_index_checker/postgresql_spec.rb
+++ b/spec/checkers/redundant_unique_index_checker/postgresql_spec.rb
@@ -140,4 +140,29 @@ RSpec.describe DatabaseConsistency::Checkers::RedundantUniqueIndexChecker, :post
         )
     end
   end
+
+  context 'when another unique index contains a column subset in a different order' do
+    before do
+      define_database_with_entity do |table|
+        table.string :first_name
+        table.string :second_name
+        table.string :birth_date
+        table.index %i[first_name birth_date], name: 'another_index', unique: true
+        table.index %i[second_name birth_date first_name], name: 'index', unique: true
+      end
+    end
+
+    specify do
+      expect(checker.report)
+        .to have_attributes(
+          checker_name: 'RedundantUniqueIndexChecker',
+          table_or_model_name: model.name,
+          column_or_attribute_name: 'index',
+          status: :fail,
+          error_slug: :redundant_unique_index,
+          error_message: nil,
+          covered_index_name: 'another_index'
+        )
+    end
+  end
 end

--- a/spec/checkers/redundant_unique_index_checker/sqlite_spec.rb
+++ b/spec/checkers/redundant_unique_index_checker/sqlite_spec.rb
@@ -140,4 +140,29 @@ RSpec.describe DatabaseConsistency::Checkers::RedundantUniqueIndexChecker, :sqli
         )
     end
   end
+
+  context 'when another unique index contains a column subset in a different order' do
+    before do
+      define_database_with_entity do |table|
+        table.string :first_name
+        table.string :second_name
+        table.string :birth_date
+        table.index %i[first_name birth_date], name: 'another_index', unique: true
+        table.index %i[second_name birth_date first_name], name: 'index', unique: true
+      end
+    end
+
+    specify do
+      expect(checker.report)
+        .to have_attributes(
+          checker_name: 'RedundantUniqueIndexChecker',
+          table_or_model_name: model.name,
+          column_or_attribute_name: 'index',
+          status: :fail,
+          error_slug: :redundant_unique_index,
+          error_message: nil,
+          covered_index_name: 'another_index'
+        )
+    end
+  end
 end


### PR DESCRIPTION
This check was incorrectly missing offenses when an index is made redundant with another unique one with a different column order.