### PR TITLE
Skip numericality validators without a range option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### [Unreleased]
+
+- Fix `NumericalityConstraintChecker` to skip `numericality` validators without a range option (e.g. bare `numericality: true`), since no `CHECK` constraint can express them.
+
 ### [3.0.8] - 2026/07/28
 
 - Fix `NumericalityConstraintChecker` false positives for attributes that have validators but no `numericality` validator. Thanks [panteo](https://github.com/panteo) for reporting this in [#309](https://github.com/djezzzl/database_consistency/issues/309)!

--- a/docs/wiki/NumericalityConstraintChecker.md
+++ b/docs/wiki/NumericalityConstraintChecker.md
@@ -1,1 +1,3 @@
-Imagine your model has `validates :age, numericality: true` validation but does not have a `CHECK` constraint for the field in the database. In that case, invalid values can still be inserted outside your model validations. This checker helps ensure numericality validations are backed by a database `CHECK` constraint.
+Imagine your model has `validates :age, numericality: { greater_than_or_equal_to: 0 }` validation but does not have a `CHECK` constraint for the field in the database. In that case, invalid values can still be inserted outside your model validations. This checker helps ensure numericality validations are backed by a database `CHECK` constraint.
+
+`numericality` validators without a range option (e.g. bare `numericality: true`) are skipped, since no CHECK constraint can express them.

--- a/lib/database_consistency/checkers/validators_fraction_checkers/numericality_constraint_checker.rb
+++ b/lib/database_consistency/checkers/validators_fraction_checkers/numericality_constraint_checker.rb
@@ -11,11 +11,25 @@ module DatabaseConsistency
       ].freeze
       PLAIN_IDENTIFIER_PATTERN =
         /\b([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)?)\b(?!\s*\()/.freeze
+      # Without one of these options, `numericality` only asserts "is a number",
+      # which the column's numeric type already guarantees. There is no
+      # corresponding CHECK constraint to look for in that case, so validators
+      # with none of these options are skipped.
+      # Listed explicitly rather than excluding the known non-range options
+      # (`only_integer`, `allow_nil`, ...) so that an unrecognized option never
+      # makes us demand a constraint that cannot exist. The tradeoff is that a
+      # future range option must be added here to be reported on.
+      RANGE_OPTIONS = %i[
+        greater_than greater_than_or_equal_to
+        less_than less_than_or_equal_to
+        equal_to other_than in
+      ].freeze
 
       private
 
       def filter(validator)
-        validator.kind == :numericality
+        validator.kind == :numericality &&
+          validator.options.slice(*RANGE_OPTIONS).any?
       end
 
       def preconditions

--- a/spec/checkers/numericality_constraint_checker_spec.rb
+++ b/spec/checkers/numericality_constraint_checker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DatabaseConsistency::Checkers::NumericalityConstraintChecker, :sq
       end
     end
 
-    let(:klass) { define_class { |klass| klass.validates :age, numericality: true } }
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { greater_than_or_equal_to: 0 } } }
 
     specify do
       expect(checker.report).to have_attributes(
@@ -44,7 +44,7 @@ RSpec.describe DatabaseConsistency::Checkers::NumericalityConstraintChecker, :sq
       end
     end
 
-    let(:klass) { define_class { |klass| klass.validates :age, numericality: true } }
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { greater_than_or_equal_to: 0 } } }
 
     specify do
       expect(checker.report).to have_attributes(
@@ -66,7 +66,7 @@ RSpec.describe DatabaseConsistency::Checkers::NumericalityConstraintChecker, :sq
       end
     end
 
-    let(:klass) { define_class { |klass| klass.validates :age, numericality: true } }
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { greater_than_or_equal_to: 0 } } }
 
     specify do
       expect(checker.report).to have_attributes(
@@ -85,7 +85,81 @@ RSpec.describe DatabaseConsistency::Checkers::NumericalityConstraintChecker, :sq
       define_database_with_entity { |table| table.integer :age }
     end
 
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { greater_than_or_equal_to: 0 } } }
+
+    specify do
+      expect(checker.report).to have_attributes(
+        checker_name: 'NumericalityConstraintChecker',
+        table_or_model_name: klass.name,
+        column_or_attribute_name: 'age',
+        status: :fail,
+        error_message: nil,
+        error_slug: :numericality_check_constraint_missing
+      )
+    end
+  end
+
+  context 'when numericality validator has no options' do
+    before do
+      define_database_with_entity { |table| table.integer :age }
+    end
+
     let(:klass) { define_class { |klass| klass.validates :age, numericality: true } }
+
+    specify do
+      expect(checker.report).to be_nil
+    end
+  end
+
+  context 'when numericality validator has only non-range options' do
+    before do
+      define_database_with_entity { |table| table.integer :age }
+    end
+
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { only_integer: true } } }
+
+    specify do
+      expect(checker.report).to be_nil
+    end
+  end
+
+  context 'when numericality validator has only allow_nil' do
+    before do
+      define_database_with_entity { |table| table.integer :age }
+    end
+
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { allow_nil: true } } }
+
+    specify do
+      expect(checker.report).to be_nil
+    end
+  end
+
+  context 'when numericality validator has a range option' do
+    before do
+      define_database_with_entity { |table| table.integer :age }
+    end
+
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { greater_than: 0 } } }
+
+    specify do
+      expect(checker.report).to have_attributes(
+        checker_name: 'NumericalityConstraintChecker',
+        table_or_model_name: klass.name,
+        column_or_attribute_name: 'age',
+        status: :fail,
+        error_message: nil,
+        error_slug: :numericality_check_constraint_missing
+      )
+    end
+  end
+
+  context 'when numericality validator combines range and non-range options' do
+    before do
+      define_database_with_entity { |table| table.integer :age }
+    end
+
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { only_integer: true, less_than: 100 } } }
 
     specify do
       expect(checker.report).to have_attributes(
@@ -120,7 +194,7 @@ RSpec.describe DatabaseConsistency::Checkers::NumericalityConstraintChecker, :sq
       end
     end
 
-    let(:klass) { define_class { |klass| klass.validates :age, numericality: true } }
+    let(:klass) { define_class { |klass| klass.validates :age, numericality: { greater_than_or_equal_to: 0 } } }
 
     specify do
       expect(checker.report).to have_attributes(
@@ -144,7 +218,7 @@ RSpec.describe DatabaseConsistency::Checkers::NumericalityConstraintChecker, :sq
     end
 
     let(:attribute) { :abs }
-    let(:klass) { define_class { |klass| klass.validates :abs, numericality: true } }
+    let(:klass) { define_class { |klass| klass.validates :abs, numericality: { greater_than_or_equal_to: 0 } } }
 
     specify do
       expect(checker.report).to have_attributes(


### PR DESCRIPTION
## Problem

`NumericalityConstraintChecker` reports a missing `CHECK` constraint for any `numericality` validator, including bare `validates :age, numericality: true`.

That only asserts "is a number", which a numeric column's type already guarantees — no `CHECK` constraint can express it, so the report is noise no one can act on. Same for validators carrying only non-range options like `only_integer` or `allow_nil`.

## Solution

`filter` now requires a comparison option in addition to the validator kind:

```ruby
RANGE_OPTIONS = %i[
  greater_than greater_than_or_equal_to
  less_than less_than_or_equal_to
  equal_to other_than in
].freeze

def filter(validator)
  validator.kind == :numericality &&
    validator.options.slice(*RANGE_OPTIONS).any?
end
```

The existing `validators.any?` guard in `preconditions` then skips the checker, which also avoids the `check_constraints` query.

| Validator | Reported? |
| --- | --- |
| `numericality: true` | no |
| `numericality: { only_integer: true }` | no |
| `numericality: { greater_than: 0 }` | yes |
| `numericality: { only_integer: true, less_than: 100 }` | yes |

Range options are whitelisted rather than excluding the known non-range ones, so an unrecognized option never makes us demand a constraint that cannot exist. The tradeoff: a future range option must be added to the list.

## Notes

Existing specs used bare `numericality: true` and would now be skipped, so they were rewritten with `greater_than_or_equal_to: 0`, matching the `age >= 0` constraints they assert against.
