### PR TITLE
Do not filter quoted identifiers as SQL keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Extend the CI test matrix to Ruby 2.6-4.0 against ActiveRecord 4.2-8.1, keeping every existing combination and adding ActiveRecord 7.2/8.0/8.1 on Ruby 3.3/3.4/4.0.
 - Allow a broad `rubocop` range in the gemspec and pin a compatible version per gemfile, so linting resolves across Ruby 2.6-4.0.
+- Fix `NumericalityConstraintChecker` false positives for columns named after SQL keywords (e.g. `limit`, `order`), whose quoted identifiers in the `CHECK` expression were filtered out as keywords. See [#313](https://github.com/djezzzl/database_consistency/issues/313).
 
 ### [3.0.9] - 2026/08/05
 

--- a/lib/database_consistency/checkers/validators_fraction_checkers/numericality_constraint_checker.rb
+++ b/lib/database_consistency/checkers/validators_fraction_checkers/numericality_constraint_checker.rb
@@ -72,9 +72,12 @@ module DatabaseConsistency
                                           .flatten
                                           .map { |identifier| identifier.split('.').last }
 
-        (quoted_identifiers + plain_identifiers).map(&:downcase).reject do |identifier|
-          SQL_KEYWORDS.include?(identifier)
-        end
+        # Keywords are only stripped from plain identifiers. A quoted identifier is
+        # always a column, even when it spells a reserved word, so filtering those
+        # would hide constraints on columns such as `"limit"` or `"order"`.
+        plain_columns = plain_identifiers.reject { |identifier| SQL_KEYWORDS.include?(identifier.downcase) }
+
+        (quoted_identifiers + plain_columns).map(&:downcase)
       end
 
       def column

--- a/spec/checkers/numericality_constraint_checker_spec.rb
+++ b/spec/checkers/numericality_constraint_checker_spec.rb
@@ -58,6 +58,30 @@ RSpec.describe DatabaseConsistency::Checkers::NumericalityConstraintChecker, :sq
     end
   end
 
+  context 'when the column is named after a SQL keyword' do
+    before do
+      define_database_with_entity do |table|
+        table.integer :limit
+        quoted_column = ActiveRecord::Base.connection.quote_column_name(:limit)
+        table.check_constraint "#{quoted_column} > 0"
+      end
+    end
+
+    let(:attribute) { :limit }
+    let(:klass) { define_class { |klass| klass.validates :limit, numericality: { greater_than: 0 } } }
+
+    specify do
+      expect(checker.report).to have_attributes(
+        checker_name: 'NumericalityConstraintChecker',
+        table_or_model_name: klass.name,
+        column_or_attribute_name: 'limit',
+        status: :ok,
+        error_message: nil,
+        error_slug: nil
+      )
+    end
+  end
+
   context 'when check constraint uses table-qualified column name' do
     before do
       define_database_with_entity do |table|


### PR DESCRIPTION
Closes #313.

## Problem

`constraint_columns` applies the `SQL_KEYWORDS` filter to quoted identifiers as well as plain ones, so a `CHECK` constraint on a column named after a reserved word disappears from the parsed set and the checker reports it as missing:

```ruby
constraint_columns('"limit" > 0::numeric') # => ["numeric"]
constraint_columns('"order" >= 0')         # => []
```

The keyword list is there to drop SQL syntax words that `PLAIN_IDENTIFIER_PATTERN` picks up. A *quoted* identifier is never syntax — it is always a column, which is precisely why the database quoted it.

## Solution

Restrict the keyword filter to plain identifiers:

```ruby
plain_columns = plain_identifiers.reject { |identifier| SQL_KEYWORDS.include?(identifier.downcase) }

(quoted_identifiers + plain_columns).map(&:downcase)
```

Unquoted expressions behave exactly as before, so `age >= 0` still yields `["age"]` and `ABS(age) >= 0` still skips the function name.

## Notes

The new spec quotes through `quote_column_name` so each adapter gets its own quoting (backticks on MySQL, double quotes on PostgreSQL/SQLite) rather than hardcoding one dialect.

Verified against a real app that hit this: with 3.0.9 the checker reported two missing constraints for `"limit"` and `"order"` columns that do exist; with this change the run is clean and no other report changes.

Full suite passes on SQLite (277 examples) and PostgreSQL (330 examples); MySQL was not run locally, so CI covers that leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
